### PR TITLE
RFC: Allow for static, freeable, String for fast handoff to Ruby

### DIFF
--- a/src/r_string.rs
+++ b/src/r_string.rs
@@ -151,7 +151,7 @@ impl RString {
     /// ```
     pub fn mark_freeable(self) {
         let mut flags = unsafe { self.r_basic_unchecked().as_ref().flags };
-        flags.bitand_assign(ruby_fl_type::RUBY_FL_USER18 as u64);
+        flags.bitand_assign(ruby_fl_type::RUBY_FL_USER18 as u64); // STR_NOFREE
         std::mem::drop(self);
     }
 


### PR DESCRIPTION
So I've been thinking about devising a mechanism to hand off a Rust `String` to Ruby in a way that:

1. Avoids any `memcpy` on the Ruby side
2. Freeable by the Ruby GC (so we don't leak memory)

This would allow for extremely fast, zero-copy handoffs of strings to Ruby.

I have a proof of concept in this PR, and I think it's close. The issue I'm running into is since `RString` implements `Copy` (and wisely so, I think), it is possible to attempt to access a potentially freed pointer on the `RString`.

Unfortunately, I do not really know of a good way around it... Was curious to hear if you had any ideas or thoughts 😄 