### PR TITLE
Bump `rb-sys` to 0.9.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.18"
+version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebbf80acc7a283f70eaeecde5eca8d503e0aaf23f737117398328048cd70077"
+checksum = "8df6990035ed930322a6b8a73783ea6af88acffd2b4322932b0eb0766a5a8673"
 dependencies = [
  "bindgen",
  "linkify",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.18"
+version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48277d27ff861590af07c8e1fd76de3aff5a37a227b745a4f42f40f914e62bc"
+checksum = "a9c3c88da760bbc2f26bbfd1acbfe9de3faa87be55feaf3413a33539d066ff3c"
 dependencies = [
  "regex",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ruby-static = ["rb-sys/ruby-static"]
 
 [dependencies]
 magnus-macros = { version = "0.1.0", path = "magnus-macros" }
-rb-sys = { version = "0.9.18", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+rb-sys = { version = "0.9.19", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
 
 [dev-dependencies]
 magnus = { path = ".", features = ["embed"] }

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rb_sys", "0.9.18"
+gem "rb_sys", "0.9.19"
 gem "rake"
 gem "rake-compiler", "1.2.0"
 gem "test-unit"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ spec.extensions = ["ext/my_example_gem/extconf.rb"]
 spec.add_runtime_dependency "rake", "> 1"
 
 # needed until rubygems supports Rust support is out of beta
-spec.add_dependency "rb_sys", "~> 0.9.18"
+spec.add_dependency "rb_sys", "~> 0.9.19"
 
 # only needed when developing or packaging your gem
 spec.add_development_dependency "rake-compiler", "~> 1.2.0"


### PR DESCRIPTION
This PR bumps `rb-sys` to 0.9.19, which adds compatibility down to Ruby 2.3+. This is important because rubygems still tests against these older versions in CI.