### PR TITLE
Add `gem` feature to reduce Windows linking bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -53,9 +53,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
@@ -129,9 +129,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
@@ -202,36 +202,36 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rb-sys"
-version = "0.9.34"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ff8b3a4d418f3604ac3781aee54a094f3f9d732fb9a2458f73a3937a9ea918"
+checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.34"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2921dcd727615d4af5a6d39cc3c1c8c9dc8e37bf2b42d44b3e101a6da2bce17"
+checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
 dependencies = [
  "bindgen",
  "linkify",
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustc-hash"
@@ -282,9 +282,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,12 @@ ruby-static = ["rb-sys/ruby-static"]
 
 [dependencies]
 magnus-macros = { version = "0.1.0", path = "magnus-macros" }
-rb-sys = { version = "~0.9.34", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+rb-sys = { version = "~0.9.37", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
 
 [dev-dependencies]
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }
 
 [package.metadata.docs.rs]
-all-features = true
+no-default-features = true
+features = ["embed", "rb-sys-interop"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rb_sys", "~> 0.9.34"
+gem "rb_sys", "~> 0.9.37"
 gem "rake"
 gem "rake-compiler", "1.2.0"
 gem "test-unit"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ spec.extensions = ["ext/my_example_gem/extconf.rb"]
 spec.add_runtime_dependency "rake", "> 1"
 
 # needed until rubygems supports Rust support is out of beta
-spec.add_dependency "rb_sys", "~> 0.9.18"
+spec.add_dependency "rb_sys", "~> 0.9.37"
 
 # only needed when developing or packaging your gem
 spec.add_development_dependency "rake-compiler", "~> 1.2.0"

--- a/examples/custom_exception_rust/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_rust/ext/ahriman/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "linkify"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d9967eb7d0bc31c39c6f52e8fce42991c0cd1f7a2078326f0b7a399a584c8d"
+checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
 dependencies = [
  "memchr",
 ]
@@ -225,21 +225,21 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.14"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bafde3b253968a803e8ebdef607ff6e259fb4a74a55135f65095df42c629eba"
+checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
 dependencies = [
- "bindgen",
- "linkify",
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.14"
+version = "0.9.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d871cc097786d39ab6196fe51fb66d54933e2a6cc7e86373f398ee794d0b22"
+checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
 dependencies = [
+ "bindgen",
+ "linkify",
  "regex",
  "shell-words",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1846,7 +1846,6 @@ pub mod value;
 
 use std::{ffi::CString, mem::transmute, os::raw::c_int};
 
-pub use magnus_macros::{init, wrap, DataTypeFunctions, TypedData};
 #[cfg(ruby_lt_2_7)]
 use ::rb_sys::rb_require;
 #[cfg(ruby_gte_2_7)]
@@ -1856,6 +1855,7 @@ use ::rb_sys::{
     rb_define_global_function, rb_define_module, rb_define_variable, rb_errinfo,
     rb_eval_string_protect, rb_set_errinfo, VALUE,
 };
+pub use magnus_macros::{init, wrap, DataTypeFunctions, TypedData};
 
 pub use crate::{
     binding::Binding,
@@ -2093,7 +2093,3 @@ where
         other => Err(Error::Jump(unsafe { transmute(other) })),
     }
 }
-
-#[cfg(not(feature = "embed"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "embed")))]
-rb_sys::ruby_abi_version!();


### PR DESCRIPTION
~It turns out the linking behavior of gems is more nuanced than we previously accounted for in magnus. On MacOS and Linux, you do not want to link in libruby, but on Windows you do. The behavior is a tricky and is not well suited for imperative interface (i.e. `features = ["link-ruby"]`. In the future, there may even be more unknown edge cases that we need to account for, so knowing that the user whats to build a `gem` makes it possible for rb-sys to do what the user _really_ wants. 

To make cross-platform linking reliable, this PR brings in the `gem` feature from rb-sys so things Just Work™️ for gems. This should reduce a class of pesky, head-scatching linker issues for windows compilation.~

In https://github.com/oxidize-rb/rb-sys/pull/94, I changed the strategy for how rb-sys detects if it should build for usage in a gem. It relies on the `create_rust_makefile` setting `--cfg=rb_sys_gem` in the `RUSTFLAGS`. This strategy makes it so `magnus` no longer needs to worry about anything when a Gem is being built, which should solve some integration headaches.

As such, we no longer need to conditionally do things like setting the `ruby_abi_version`, since that is now now handled automatically.