### PR TITLE
Add `mswin` support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
-[build]
 # Without this flag, when linking static libruby, the linker removes symbols
 # (such as `_rb_ext_ractor_safe`) which it thinks are dead code... but they are
 # not, and they need to be included for the `embed` feature to work.
+#
+# We avoid this on windows due to https://github.com/rust-lang/rust/issues/90056
+[target.'cfg(not(target_family = "windows"))']
 rustflags = ["-C", "link-dead-code=on"]
-rustdocflags = ["-C", "link-dead-code=on"]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os:
           - ubuntu-latest
@@ -22,6 +22,11 @@ jobs:
           - head
         rustup-toolchain:
           - "1.51"
+          - "stable"
+        include:
+          - os: windows-latest
+            ruby-version: mswin
+            rustup-toolchain: stable
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 *.so
 Gemfile.lock
 target/
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,15 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linkify"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "magnus"
 version = "0.3.2"
 dependencies = [
@@ -220,21 +211,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
+checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
+checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
 dependencies = [
  "bindgen",
- "linkify",
  "regex",
  "shell-words",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ruby-static = ["rb-sys/ruby-static"]
 
 [dependencies]
 magnus-macros = { version = "0.1.0", path = "magnus-macros" }
-rb-sys = { version = "~0.9.37", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+rb-sys = { version = "~0.9.38", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
 
 [dev-dependencies]
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rb_sys", "~> 0.9.37"
+gem "rb_sys", "~> 0.9.38"
 gem "rake"
 gem "rake-compiler", "1.2.0"
 gem "test-unit"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ spec.extensions = ["ext/my_example_gem/extconf.rb"]
 spec.add_runtime_dependency "rake", "> 1"
 
 # needed until rubygems supports Rust support is out of beta
-spec.add_dependency "rb_sys", "~> 0.9.37"
+spec.add_dependency "rb_sys", "~> 0.9.38"
 
 # only needed when developing or packaging your gem
 spec.add_development_dependency "rake-compiler", "~> 1.2.0"

--- a/examples/custom_exception_ruby/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_ruby/ext/ahriman/Cargo.lock
@@ -151,15 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linkify"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "magnus"
 version = "0.3.2"
 dependencies = [
@@ -225,21 +216,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
+checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
+checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
 dependencies = [
  "bindgen",
- "linkify",
  "regex",
  "shell-words",
 ]

--- a/examples/custom_exception_rust/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_rust/ext/ahriman/Cargo.lock
@@ -151,15 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linkify"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "magnus"
 version = "0.3.2"
 dependencies = [
@@ -225,21 +216,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
+checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
+checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
 dependencies = [
  "bindgen",
- "linkify",
  "regex",
  "shell-words",
 ]

--- a/examples/rust_blank/ext/rust_blank/Cargo.lock
+++ b/examples/rust_blank/ext/rust_blank/Cargo.lock
@@ -144,15 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linkify"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "magnus"
 version = "0.3.2"
 dependencies = [
@@ -218,21 +209,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba942b6777ea18ded013b267023a9c98994557e6539e43740de9e75084cb124"
+checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.37"
+version = "0.9.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35109e1a11ef8d1a988db242ab2ba2e80170f9f5a28f88ab30184a2cea8e09b"
+checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
 dependencies = [
  "bindgen",
- "linkify",
  "regex",
  "shell-words",
 ]

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use rb_sys::{
     rb_gc_adjust_memory_usage, rb_gc_count, rb_gc_disable, rb_gc_enable, rb_gc_mark,
     rb_gc_mark_locations, rb_gc_register_address, rb_gc_register_mark_object, rb_gc_start,
-    rb_gc_stat, rb_gc_unregister_address, ssize_t, VALUE,
+    rb_gc_stat, rb_gc_unregister_address, VALUE,
 };
 #[cfg(ruby_gte_2_7)]
 use rb_sys::{rb_gc_location, rb_gc_mark_movable};
@@ -16,6 +16,12 @@ use crate::{
     symbol::Symbol,
     value::{ReprValue, Value, QNIL},
 };
+
+#[cfg(target_pointer_width = "64")]
+type DiffSize = i64;
+
+#[cfg(target_pointer_width = "32")]
+type DiffSize = i32;
 
 /// Mark an Object.
 ///
@@ -164,8 +170,8 @@ pub fn start() {
 /// the process is using.
 ///
 /// Pass negative numbers to indicate memory has been freed.
-pub fn adjust_memory_usage(diff: i32) {
-    unsafe { rb_gc_adjust_memory_usage(diff as ssize_t) };
+pub fn adjust_memory_usage(diff: DiffSize) {
+    unsafe { rb_gc_adjust_memory_usage(diff) };
 }
 
 /// Returns the number of garbage collections that have been run since the


### PR DESCRIPTION
Ruby 3.2 will be adding support for mswin builds (which uses `msvc` toolchain rather than `mingq`). We already support this in rb-sys, and the setup-ruby-and-ruby GitHub action. This PR adds official support for magnus.

depends on #25 