### PR TITLE
Add support for rubies compiled with `USE_FLONUM=0`, fix `mingw` cross-compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "magnus",
  "magnus-macros",
  "rb-sys",
+ "rb-sys-env",
 ]
 
 [[package]]
@@ -211,23 +212,29 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
+checksum = "31bb5cd8565cd4dd97dcf7a04e3b4e5401ce379d34496c34e866ce806277a408"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
+checksum = "de4bbf05b48f0c01b9b8e3b26f02769b097185b8d649831c652cb8a9946494a2"
 dependencies = [
  "bindgen",
  "regex",
  "shell-words",
 ]
+
+[[package]]
+name = "rb-sys-env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c38752410925faeb82c400c06ba2fd9ee6aa8f719dd33994c9e53f5242d25f"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,13 @@ ruby-static = ["rb-sys/ruby-static"]
 
 [dependencies]
 magnus-macros = { version = "0.1.0", path = "magnus-macros" }
-rb-sys = { version = "~0.9.38", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+rb-sys = { version = "~0.9.39", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
 
 [dev-dependencies]
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }
+
+[build-dependencies]
+rb-sys-env = "0.1.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rb_sys", "~> 0.9.38"
+gem "rb_sys", "~> 0.9.39"
 gem "rake"
 gem "rake-compiler", "1.2.0"
 gem "test-unit"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ spec.extensions = ["ext/my_example_gem/extconf.rb"]
 spec.add_runtime_dependency "rake", "> 1"
 
 # needed until rubygems supports Rust support is out of beta
-spec.add_dependency "rb_sys", "~> 0.9.38"
+spec.add_dependency "rb_sys", "~> 0.9.39"
 
 # only needed when developing or packaging your gem
 spec.add_development_dependency "rake-compiler", "~> 1.2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,48 +1,5 @@
-use std::env;
-
-const RUBY_VERSIONS: [(u8, u8); 4] = [(2, 7), (3, 0), (3, 1), (3, 2)];
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-env-changed=RUBY");
-    println!("cargo:rerun-if-env-changed=RUBY_VERSION");
-
-    configure_libruby();
-
-    let major = dep_rb_value("MAJOR").parse::<u8>()?;
-    let minor = dep_rb_value("MINOR").parse::<u8>()?;
-
-    let version = (major, minor);
-
-    for &v in &RUBY_VERSIONS {
-        if version < v {
-            println!(r#"cargo:rustc-cfg=ruby_lt_{}_{}"#, v.0, v.1);
-        }
-        if version <= v {
-            println!(r#"cargo:rustc-cfg=ruby_lte_{}_{}"#, v.0, v.1);
-        }
-        if version == v {
-            println!(r#"cargo:rustc-cfg=ruby_{}_{}"#, v.0, v.1);
-        }
-        if version >= v {
-            println!(r#"cargo:rustc-cfg=ruby_gte_{}_{}"#, v.0, v.1);
-        }
-        if version > v {
-            println!(r#"cargo:rustc-cfg=ruby_gt_{}_{}"#, v.0, v.1);
-        }
-    }
+    let _ = rb_sys_env::activate()?;
 
     Ok(())
-}
-
-/// Setup libruby. Ideally, `rb-sys` linker flags could be inherited but that's
-/// not currently possible with Cargo.
-fn configure_libruby() {
-    println!("cargo:rustc-link-search=native={}", dep_rb_value("LIBDIR"));
-}
-
-/// Gets a value from the rb-sys build output.
-fn dep_rb_value(key: &str) -> String {
-    let key = format!("DEP_RB_{}", key);
-    println!("cargo:rerun-if-env-changed={}", key);
-    env::var(key).unwrap().to_string()
 }

--- a/examples/custom_exception_ruby/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_ruby/ext/ahriman/Cargo.lock
@@ -156,6 +156,7 @@ version = "0.3.2"
 dependencies = [
  "magnus-macros",
  "rb-sys",
+ "rb-sys-env",
 ]
 
 [[package]]
@@ -216,23 +217,29 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
+checksum = "31bb5cd8565cd4dd97dcf7a04e3b4e5401ce379d34496c34e866ce806277a408"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
+checksum = "de4bbf05b48f0c01b9b8e3b26f02769b097185b8d649831c652cb8a9946494a2"
 dependencies = [
  "bindgen",
  "regex",
  "shell-words",
 ]
+
+[[package]]
+name = "rb-sys-env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c38752410925faeb82c400c06ba2fd9ee6aa8f719dd33994c9e53f5242d25f"
 
 [[package]]
 name = "regex"

--- a/examples/custom_exception_rust/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_rust/ext/ahriman/Cargo.lock
@@ -156,6 +156,7 @@ version = "0.3.2"
 dependencies = [
  "magnus-macros",
  "rb-sys",
+ "rb-sys-env",
 ]
 
 [[package]]
@@ -216,23 +217,29 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
+checksum = "31bb5cd8565cd4dd97dcf7a04e3b4e5401ce379d34496c34e866ce806277a408"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
+checksum = "de4bbf05b48f0c01b9b8e3b26f02769b097185b8d649831c652cb8a9946494a2"
 dependencies = [
  "bindgen",
  "regex",
  "shell-words",
 ]
+
+[[package]]
+name = "rb-sys-env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c38752410925faeb82c400c06ba2fd9ee6aa8f719dd33994c9e53f5242d25f"
 
 [[package]]
 name = "regex"

--- a/examples/rust_blank/ext/rust_blank/Cargo.lock
+++ b/examples/rust_blank/ext/rust_blank/Cargo.lock
@@ -149,6 +149,7 @@ version = "0.3.2"
 dependencies = [
  "magnus-macros",
  "rb-sys",
+ "rb-sys-env",
 ]
 
 [[package]]
@@ -209,23 +210,29 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d346c692e9a959d89446f5d0071e82fc0670428c111e21dd776f88434594c"
+checksum = "31bb5cd8565cd4dd97dcf7a04e3b4e5401ce379d34496c34e866ce806277a408"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.38"
+version = "0.9.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ebebd558e60424cd91c548a224d54d6b0e2750ed5ef496905019af4a3bb366"
+checksum = "de4bbf05b48f0c01b9b8e3b26f02769b097185b8d649831c652cb8a9946494a2"
 dependencies = [
  "bindgen",
  "regex",
  "shell-words",
 ]
+
+[[package]]
+name = "rb-sys-env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c38752410925faeb82c400c06ba2fd9ee6aa8f719dd33994c9e53f5242d25f"
 
 [[package]]
 name = "regex"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1883,9 +1883,12 @@ pub use crate::{
     range::Range,
     symbol::Symbol,
     try_convert::{ArgList, TryConvert},
-    value::{Fixnum, Flonum, StaticSymbol, Value, QFALSE, QNIL, QTRUE},
+    value::{Fixnum, StaticSymbol, Value, QFALSE, QNIL, QTRUE},
 };
 use crate::{error::protect, method::Method, value::private::ReprValue as _};
+
+#[cfg(ruby_use_flonum)]
+pub use crate::value::Flonum;
 
 /// Utility to simplify initialising a static with [`std::sync::Once`].
 ///

--- a/src/try_convert.rs
+++ b/src/try_convert.rs
@@ -10,8 +10,11 @@ use crate::{
     r_array::RArray,
     r_hash::RHash,
     r_string::RString,
-    value::{Fixnum, Flonum, Value, QNIL},
+    value::{Fixnum, Value, QNIL},
 };
+
+#[cfg(ruby_use_flonum)]
+use crate::value::Flonum;
 
 /// Conversions from [`Value`] to Rust types.
 pub trait TryConvert: Sized {
@@ -143,6 +146,7 @@ impl TryConvert for f64 {
         if let Some(fixnum) = Fixnum::from_value(val) {
             return Ok(fixnum.to_isize() as f64);
         }
+        #[cfg(ruby_use_flonum)]
         if let Some(flonum) = Flonum::from_value(val) {
             return Ok(flonum.to_f64());
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,8 @@
 //! Types for working with Ruby's VALUE type, representing all objects, and 'immediate' values such as Fixnum.
 
+#[cfg(ruby_use_flonum)]
+mod flonum;
+
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -14,12 +17,14 @@ use std::{
 
 use rb_sys::{
     rb_any_to_s, rb_block_call, rb_check_funcall, rb_check_id, rb_check_id_cstr,
-    rb_check_symbol_cstr, rb_enumeratorize_with_size, rb_eql, rb_equal, rb_float_new_in_heap,
-    rb_funcall_with_block, rb_funcallv, rb_gc_register_address, rb_gc_register_mark_object,
-    rb_gc_unregister_address, rb_id2name, rb_id2sym, rb_inspect, rb_intern3, rb_ll2inum,
-    rb_obj_as_string, rb_obj_classname, rb_obj_freeze, rb_obj_is_kind_of, rb_obj_respond_to,
-    rb_sym2id, rb_ull2inum, ruby_fl_type, ruby_special_consts, ruby_value_type, RBasic, ID, VALUE,
+    rb_check_symbol_cstr, rb_enumeratorize_with_size, rb_eql, rb_equal, rb_funcall_with_block,
+    rb_funcallv, rb_gc_register_address, rb_gc_register_mark_object, rb_gc_unregister_address,
+    rb_id2name, rb_id2sym, rb_inspect, rb_intern3, rb_ll2inum, rb_obj_as_string, rb_obj_classname,
+    rb_obj_freeze, rb_obj_is_kind_of, rb_obj_respond_to, rb_sym2id, rb_ull2inum, ruby_fl_type,
+    ruby_special_consts, ruby_value_type, RBasic, ID, VALUE,
 };
+
+pub use flonum::Flonum;
 
 // These don't seem to appear consistently in bindgen output, not sure if they
 // aren't consistently defined in the headers or what. Lets just do it
@@ -39,7 +44,6 @@ use crate::{
     method::{Block, BlockReturn},
     module::Module,
     r_bignum::RBignum,
-    r_float::RFloat,
     r_string::RString,
     symbol::Symbol,
     try_convert::{ArgList, TryConvert, TryConvertOwned},
@@ -159,7 +163,7 @@ impl Value {
     }
 
     #[inline]
-    fn is_flonum(self) -> bool {
+    pub(crate) fn is_flonum(self) -> bool {
         self.as_rb_value() & ruby_special_consts::RUBY_FLONUM_MASK as VALUE
             == ruby_special_consts::RUBY_FLONUM_FLAG as VALUE
     }
@@ -2216,148 +2220,3 @@ impl From<Symbol> for Id {
         Self::new(unsafe { rb_sym2id(sym.as_rb_value()) })
     }
 }
-
-/// A Value known to be a flonum, Ruby's internal representation of lower
-/// precision floating point numbers.
-///
-/// See also `Float`.
-///
-/// All [`Value`] methods should be available on this type through [`Deref`],
-/// but some may be missed by this documentation.
-#[derive(Clone, Copy)]
-#[repr(transparent)]
-pub struct Flonum(NonZeroValue);
-
-impl Flonum {
-    /// Return `Some(Flonum)` if `val` is a `Flonum`, `None` otherwise.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use magnus::{eval, Flonum};
-    /// # let _cleanup = unsafe { magnus::embed::init() };
-    ///
-    /// assert!(Flonum::from_value(eval("1.7272337110188893e-77").unwrap()).is_some());
-    /// // representable as a Float, but Flonum does not have enough precision
-    /// assert!(Flonum::from_value(eval("1.7272337110188890e-77").unwrap()).is_none());
-    /// ```
-    #[inline]
-    pub fn from_value(val: Value) -> Option<Self> {
-        unsafe {
-            val.is_flonum()
-                .then(|| Self(NonZeroValue::new_unchecked(val)))
-        }
-    }
-
-    #[inline]
-    pub(crate) unsafe fn from_rb_value_unchecked(val: VALUE) -> Self {
-        Self(NonZeroValue::new_unchecked(Value::new(val)))
-    }
-
-    #[inline]
-    pub(crate) fn from_f64_impl(d: f64) -> Option<Self> {
-        let v = d.to_bits();
-        let bits = v >> 60 & 0x7;
-        if v != 0x3000000000000000 && bits.wrapping_sub(3) & !0x01 == 0 {
-            return Some(unsafe { Self::from_rb_value_unchecked(v.rotate_left(3) & !0x01 | 0x02) });
-        } else if v == 0 {
-            return Some(unsafe { Self::from_rb_value_unchecked(0x8000000000000002) });
-        }
-        None
-    }
-
-    /// Create a new `Flonum` from a `f64.`
-    ///
-    /// Returns `Ok(Flonum)` if `n` can be represented as a `Flonum`, otherwise
-    /// returns `Err(RFloat)`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use magnus::{eval, Flonum};
-    /// # let _cleanup = unsafe { magnus::embed::init() };
-    ///
-    /// assert!(Flonum::from_f64(1.7272337110188893e-77).is_ok());
-    /// // representable as a Float, but Flonum does not have enough precision
-    /// assert!(Flonum::from_f64(1.7272337110188890e-77).is_err());
-    /// ```
-    #[inline]
-    pub fn from_f64(n: f64) -> Result<Self, RFloat> {
-        Self::from_f64_impl(n)
-            .ok_or_else(|| unsafe { RFloat::from_rb_value_unchecked(rb_float_new_in_heap(n)) })
-    }
-
-    /// Convert `self` to a `f64`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use magnus::{eval, Flonum};
-    /// # let _cleanup = unsafe { magnus::embed::init() };
-    ///
-    /// assert_eq!(eval::<Flonum>("2.0").unwrap().to_f64(), 2.0);
-    /// ```
-    #[inline]
-    pub fn to_f64(self) -> f64 {
-        let v = self.as_rb_value();
-        if v != 0x8000000000000002 {
-            let b63 = v >> 63;
-            let v = (2_u64.wrapping_sub(b63) | v & !0x03).rotate_right(3);
-            return f64::from_bits(v);
-        }
-        0.0
-    }
-}
-
-impl Deref for Flonum {
-    type Target = Value;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.get_ref()
-    }
-}
-
-impl fmt::Display for Flonum {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", unsafe { self.to_s_infallible() })
-    }
-}
-
-impl fmt::Debug for Flonum {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inspect())
-    }
-}
-
-impl From<Flonum> for Value {
-    fn from(val: Flonum) -> Self {
-        *val
-    }
-}
-
-unsafe impl private::ReprValue for Flonum {
-    fn to_value(self) -> Value {
-        *self
-    }
-
-    unsafe fn from_value_unchecked(val: Value) -> Self {
-        Self(NonZeroValue::new_unchecked(val))
-    }
-}
-
-impl ReprValue for Flonum {}
-
-impl TryConvert for Flonum {
-    fn try_convert(val: Value) -> Result<Self, Error> {
-        let float = val.try_convert::<Float>()?;
-        if let Some(flonum) = Flonum::from_value(*float) {
-            Ok(flonum)
-        } else {
-            Err(Error::new(
-                exception::range_error(),
-                "float out of range for flonum",
-            ))
-        }
-    }
-}
-impl TryConvertOwned for Flonum {}

--- a/src/value/flonum.rs
+++ b/src/value/flonum.rs
@@ -1,0 +1,156 @@
+use std::{fmt, ops::Deref};
+
+use rb_sys::{rb_float_new_in_heap, VALUE};
+
+use crate::{
+    exception,
+    try_convert::TryConvertOwned,
+    value::{private, NonZeroValue, ReprValue},
+    Error, Float, RFloat, TryConvert, Value,
+};
+
+/// A Value known to be a flonum, Ruby's internal representation of lower
+/// precision floating point numbers.
+///
+/// See also `Float`.
+///
+/// All [`Value`] methods should be available on this type through [`Deref`],
+/// but some may be missed by this documentation.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct Flonum(NonZeroValue);
+
+impl Flonum {
+    /// Return `Some(Flonum)` if `val` is a `Flonum`, `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::{eval, Flonum};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// assert!(Flonum::from_value(eval("1.7272337110188893e-77").unwrap()).is_some());
+    /// // representable as a Float, but Flonum does not have enough precision
+    /// assert!(Flonum::from_value(eval("1.7272337110188890e-77").unwrap()).is_none());
+    /// ```
+    #[inline]
+    pub fn from_value(val: Value) -> Option<Self> {
+        unsafe {
+            val.is_flonum()
+                .then(|| Self(NonZeroValue::new_unchecked(val)))
+        }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_rb_value_unchecked(val: VALUE) -> Self {
+        Self(NonZeroValue::new_unchecked(Value::new(val)))
+    }
+
+    #[inline]
+    pub(crate) fn from_f64_impl(d: f64) -> Option<Self> {
+        let v = d.to_bits();
+        let bits = v >> 60 & 0x7;
+        if v != 0x3000000000000000 && bits.wrapping_sub(3) & !0x01 == 0 {
+            return Some(unsafe { Self::from_rb_value_unchecked(v.rotate_left(3) & !0x01 | 0x02) });
+        } else if v == 0 {
+            return Some(unsafe { Self::from_rb_value_unchecked(0x8000000000000002) });
+        }
+        None
+    }
+
+    /// Create a new `Flonum` from a `f64.`
+    ///
+    /// Returns `Ok(Flonum)` if `n` can be represented as a `Flonum`, otherwise
+    /// returns `Err(RFloat)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::{eval, Flonum};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// assert!(Flonum::from_f64(1.7272337110188893e-77).is_ok());
+    /// // representable as a Float, but Flonum does not have enough precision
+    /// assert!(Flonum::from_f64(1.7272337110188890e-77).is_err());
+    /// ```
+    #[inline]
+    pub fn from_f64(n: f64) -> Result<Self, RFloat> {
+        Self::from_f64_impl(n)
+            .ok_or_else(|| unsafe { RFloat::from_rb_value_unchecked(rb_float_new_in_heap(n)) })
+    }
+
+    /// Convert `self` to a `f64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::{eval, Flonum};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// assert_eq!(eval::<Flonum>("2.0").unwrap().to_f64(), 2.0);
+    /// ```
+    #[cfg(ruby_use_flonum)]
+    #[inline]
+    pub fn to_f64(self) -> f64 {
+        let v = self.as_rb_value();
+        if v != 0x8000000000000002 {
+            let b63 = v >> 63;
+            let v = (2_u64.wrapping_sub(b63) | v & !0x03).rotate_right(3);
+            return f64::from_bits(v);
+        }
+        0.0
+    }
+}
+
+impl Deref for Flonum {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.get_ref()
+    }
+}
+
+impl fmt::Display for Flonum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", unsafe { self.to_s_infallible() })
+    }
+}
+
+impl fmt::Debug for Flonum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inspect())
+    }
+}
+
+impl From<Flonum> for Value {
+    fn from(val: Flonum) -> Self {
+        *val
+    }
+}
+
+unsafe impl private::ReprValue for Flonum {
+    fn to_value(self) -> Value {
+        *self
+    }
+
+    unsafe fn from_value_unchecked(val: Value) -> Self {
+        Self(NonZeroValue::new_unchecked(val))
+    }
+}
+
+impl ReprValue for Flonum {}
+
+impl TryConvert for Flonum {
+    fn try_convert(val: Value) -> Result<Self, Error> {
+        let float = val.try_convert::<Float>()?;
+        if let Some(flonum) = Flonum::from_value(*float) {
+            Ok(flonum)
+        } else {
+            Err(Error::new(
+                exception::range_error(),
+                "float out of range for flonum",
+            ))
+        }
+    }
+}
+impl TryConvertOwned for Flonum {}


### PR DESCRIPTION
This PR makes magnus work when `USE_FLONUM=0`. I've verified this compiling Ruby with `CPPFLAGS="-DUSE_FLONUM=0"`, and things are working.

As part of this work, there are a number of integration issues that [I fixed by introducing a `rb-sys-env` crate](https://github.com/oxidize-rb/rb-sys/pull/99). Incidentally, this [fixes cross-compilation issues for `x64-mingw32` and `x64-mingw32-ucrt`](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3448763186/jobs/5756065948).