### PR TITLE
Fix memory leak in `error::raise`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -273,8 +273,9 @@ pub(crate) fn raise(e: Error) -> ! {
             // We use `rb_exc_new_str` here because `rb_raise` nevers frees the
             // string buffer, and causes memory leaks. Using `rb_exc_new_str`
             // allows the GC deallocate the message later.
-            let msg = RString::from(msg.as_ref()).as_rb_value();
-            let exc = unsafe { rb_exc_new_str(class.as_rb_value(), msg) };
+            let rmsg = RString::from(msg.as_ref()).as_rb_value();
+            drop(msg);
+            let exc = unsafe { rb_exc_new_str(class.as_rb_value(), rmsg) };
             unsafe { rb_exc_raise(exc) };
 
             unreachable!()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,7 @@
 //! * `rb_eval_string_protect`: [`eval()`] or [`eval!`].
 // * `rb_eval_string_wrap`:
 // * `rb_exc_fatal`:
-// * `rb_exc_new`:
+//! * `rb_exc_new`: See [`error::raise`].
 // * `rb_exc_new_cstr`:
 // * `rb_exc_new_str`:
 //! * `rb_exc_raise`: Return [`Error`].
@@ -1259,7 +1259,7 @@
 // * `rb_ractor_stdin_set`:
 // * `rb_ractor_stdout`:
 // * `rb_ractor_stdout_set`:
-//! * `rb_raise`: Return [`Error`].
+// * `rb_raise`:
 // * `rb_random_base_init`:
 // * `rb_random_bytes`:
 // * `RB_RANDOM_DATA_INIT_PARENT`:


### PR DESCRIPTION
When running [`ruby_memcheck`] against [`wasmtime-rb`]'s test suite, and Valgrind [detected a bunch of small leaks coming from `error::raise](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3457450066/jobs/5770886620).

Turns out, `rb_raise` never frees the error message buffer so the memory for every raised `Error::Error` leaks.

To fix this, `error:raise` now uses `rb_exc_new_str` which will allow the Ruby GC to free the `RString` error message. With this change, [Valgrind no longer detects the leak](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3457832824/jobs/5771647954).

[`ruby_memcheck`]: https://github.com/Shopify/ruby_memcheck
[`wasmtime-rb`]: https://github.com/bytecodealliance/wasmtime-rb