### PR TITLE
Small nit: `s/immediatly/immediately`

### DIFF
--- a/magnus-macros/src/lib.rs
+++ b/magnus-macros/src/lib.rs
@@ -1,7 +1,7 @@
 //! Derive and proc macros for magnus.
 //!
 //! ```
-//! #[magnus::wrap(class = "RbPoint", free_immediatly, size)]
+//! #[magnus::wrap(class = "RbPoint", free_immediately, size)]
 //! struct Point {
 //!     x: isize,
 //!     y: isize,
@@ -58,7 +58,7 @@ struct InitAttributes {
 /// ```
 /// use magnus::{define_module, function, method, prelude::*, Error};
 ///
-/// #[magnus::wrap(class = "Euclid::Point", free_immediatly, size)]
+/// #[magnus::wrap(class = "Euclid::Point", free_immediately, size)]
 /// struct Point {
 ///     x: isize,
 ///     y: isize,
@@ -145,7 +145,7 @@ pub fn init(attrs: TokenStream, item: TokenStream) -> TokenStream {
 ///    Supports module paths, e.g. `Foo::Bar::Baz`.
 /// * `name = "..."` - debug name for the type, must be unique. Defaults to the
 ///   class name.
-/// * `free_immediatly` - Drop the Rust type as soon as the Ruby object has
+/// * `free_immediately` - Drop the Rust type as soon as the Ruby object has
 ///   been garbage collected. This is only safe to set if the type's [`Drop`]
 ///   implmentation does not call Ruby.
 /// * `size` - Report the [`std::mem::size_of_val`] of the type to Ruby, used
@@ -154,7 +154,7 @@ pub fn init(attrs: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// #[magnus::wrap(class = "RbPoint", free_immediatly, size)]
+/// #[magnus::wrap(class = "RbPoint", free_immediately, size)]
 /// struct Point {
 ///     x: isize,
 ///     y: isize,
@@ -219,6 +219,8 @@ struct TypedDataAttributes {
     #[darling(default)]
     compact: Flag,
     #[darling(default)]
+    free_immediately: Flag,
+    #[darling(default)]
     free_immediatly: Flag,
     #[darling(default)]
     wb_protected: Flag,
@@ -239,7 +241,7 @@ struct TypedDataAttributes {
 ///    Supports module paths, e.g. `Foo::Bar::Baz`.
 /// * `name = "..."` - debug name for the type, must be unique. Defaults to the
 ///   class name.
-/// * `free_immediatly` - Drop the Rust type as soon as the Ruby object has
+/// * `free_immediately` - Drop the Rust type as soon as the Ruby object has
 ///   been garbage collected. This is only safe to set if the type's [`Drop`]
 ///   and `DataTypeFunctions::free` implementations do not call Ruby.
 /// * `mark` - Enable Ruby calling the `DataTypeFunctions::mark` function.
@@ -254,7 +256,7 @@ struct TypedDataAttributes {
 /// use magnus::{DataTypeFunctions, TypedData};
 ///
 /// #[derive(DataTypeFunctions, TypedData)]
-/// #[magnus(class = "RbPoint", size, free_immediatly)]
+/// #[magnus(class = "RbPoint", size, free_immediately)]
 /// struct Point {
 ///     x: isize,
 ///     y: isize,
@@ -284,7 +286,7 @@ struct TypedDataAttributes {
 /// use magnus::{DataTypeFunctions, TypedData};
 ///
 /// #[derive(TypedData)]
-/// #[magnus(class = "Name", size, free_immediatly)]
+/// #[magnus(class = "Name", size, free_immediately)]
 /// struct Name {
 ///     first: String,
 ///     last: String,
@@ -351,6 +353,9 @@ pub fn derive_typed_data(input: TokenStream) -> TokenStream {
     }
     if attrs.compact.is_some() {
         builder.push(quote! { builder.compact(); });
+    }
+    if attrs.free_immediately.is_some() {
+        builder.push(quote! { builder.free_immediately(); });
     }
     if attrs.free_immediatly.is_some() {
         builder.push(quote! { builder.free_immediatly(); });

--- a/src/block.rs
+++ b/src/block.rs
@@ -310,7 +310,7 @@ where
     impl DataTypeFunctions for Closure {}
     let data_type = memoize!(DataType: {
         let mut builder = DataType::builder::<Closure>("rust closure");
-        builder.free_immediatly();
+        builder.free_immediately();
         builder.build()
     });
     let boxed = Box::new(func);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! ```
 //! use magnus::{define_module, function, method, prelude::*, Error};
 //!
-//! #[magnus::wrap(class = "Euclid::Point", free_immediatly, size)]
+//! #[magnus::wrap(class = "Euclid::Point", free_immediately, size)]
 //! struct Point {
 //!     x: isize,
 //!     y: isize,

--- a/src/r_typed_data.rs
+++ b/src/r_typed_data.rs
@@ -338,7 +338,7 @@ pub struct DataTypeBuilder<T> {
     mark: bool,
     size: bool,
     compact: bool,
-    free_immediatly: bool,
+    free_immediately: bool,
     wb_protected: bool,
     frozen_shareable: bool,
     phantom: PhantomData<T>,
@@ -358,7 +358,7 @@ where
             mark: false,
             size: false,
             compact: false,
-            free_immediatly: false,
+            free_immediately: false,
             wb_protected: false,
             frozen_shareable: false,
             phantom: Default::default(),
@@ -380,15 +380,21 @@ where
         self.compact = true;
     }
 
-    /// Enable the 'free_immediatly' flag.
+    /// Enable the 'free_immediately' flag.
     ///
     /// This is safe to do as long as the `<T as DataTypeFunctions>::free`
     /// function or `T`'s drop function don't call Ruby in any way.
     ///
     /// If safe this should be enabled as this performs better and is more
     /// memory efficient.
+    pub fn free_immediately(&mut self) {
+        self.free_immediately = true;
+    }
+
+    #[doc(hidden)]
+    #[deprecated = "Typo, use DataTypeBuilder::free_immediately instead"]
     pub fn free_immediatly(&mut self) {
-        self.free_immediatly = true;
+        self.free_immediately = true;
     }
 
     /// Enable the 'write barrier protected' flag.
@@ -409,7 +415,7 @@ where
     /// Consume the builder and create a DataType.
     pub fn build(self) -> DataType {
         let mut flags = 0_usize as VALUE;
-        if self.free_immediatly {
+        if self.free_immediately {
             flags |= RUBY_TYPED_FREE_IMMEDIATELY as VALUE;
         }
         if self.wb_protected {

--- a/tests/typed_data.rs
+++ b/tests/typed_data.rs
@@ -10,7 +10,7 @@ macro_rules! rb_assert {
     };
 }
 
-#[magnus::wrap(class = "Example", free_immediatly)]
+#[magnus::wrap(class = "Example", free_immediately)]
 struct Example {
     value: String,
 }


### PR DESCRIPTION
Small typo fix. I decided to go the deprecate route so users can upgrade more easily.