### PR TITLE
Re-enable `mswin` builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,10 +23,10 @@ jobs:
         rustup-toolchain:
           - "1.51"
           - stable
-        # include:
-        #   - os: windows-latest
-        #     ruby-version: mswin
-        #     rustup-toolchain: stable
+        include:
+          - os: windows-latest
+            ruby-version: mswin
+            rustup-toolchain: stable
         exclude:
           - os: macos-latest
             rustup-toolchain: "1.51"


### PR DESCRIPTION
GitHub actions runner induced a breaking change, but I fixed in https://github.com/oxidize-rb/actions/commit/27945b582cd8f0e17392e8d0690012979923777e