### PR TITLE
Make `gc::mark_slice` mark the entire slice

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,6 +1,6 @@
 //! Functions for working with Ruby's Garbage Collector.
 
-use std::ops::Deref;
+use std::ops::{Deref, Range};
 
 use rb_sys::{
     rb_gc_adjust_memory_usage, rb_gc_count, rb_gc_disable, rb_gc_enable, rb_gc_mark,
@@ -42,14 +42,14 @@ pub fn mark_slice<T>(values: &[T])
 where
     T: ReprValue,
 {
-    if let (Some(start), Some(end)) = (values.first(), values.last()) {
-        unsafe {
-            rb_gc_mark_locations(
-                start as *const _ as *const VALUE,
-                end as *const _ as *const VALUE,
-            )
-        }
-    };
+    let Range { start, end } = values.as_ptr_range();
+
+    unsafe {
+        rb_gc_mark_locations(
+            start as *const _ as *const VALUE,
+            end as *const _ as *const VALUE,
+        )
+    }
 }
 
 /// Mark an Object and let Ruby know it is moveable.


### PR DESCRIPTION
When trying to use `gc::mark_slice`, I realized that the last element of the slice never gets marked. This is [how `gc_mark_locations` is implemented in Ruby 3.1](https://github.com/ruby/ruby/blob/4491bb740a9506d76391ac44bb2fe6e483fec952/gc.c#L6180-L6188):

```c
static void
gc_mark_locations(rb_objspace_t *objspace, const VALUE *start, const VALUE *end, void (*cb)(rb_objspace_t *, VALUE))
{
    long n;

    if (end <= start) return;
    n = end - start;
    each_location(objspace, start, n, cb);
}
```

It marks `n` VALUEs, where `n = end-start`. By sending the first and the last VALUEs of the slice, `n` ends up `slice.len() - 1`, omitting the last element.

~I'm fixing this by throwing a +1 on the last element. I don't know if that's the most idiomatic fix, but worked when I tried it in wasmtime-rb.~ Updated to use [`slice::as_ptr_range`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.as_ptr_range) as recommended.