### PR TITLE
Implement `rb_undef_alloc_func`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - `typed_data::Obj<T>`, a Ruby object wrapping a Rust type known to be `T`.
-- `Class::undef_alloc_foc`, a function to remove a class' allocator function.
+- `Class::undef_alloc_func`, a function to remove a class' allocator function.
 
 ### Changed
 - When converting Ruby values to `RArray` (or `Vec<T>`, `[T; 1]`, or `(T,)`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - `typed_data::Obj<T>`, a Ruby object wrapping a Rust type known to be `T`.
+- `Class::undef_alloc_foc`, a function to remove a class' allocator function.
 
 ### Changed
 - When converting Ruby values to `RArray` (or `Vec<T>`, `[T; 1]`, or `(T,)`),

--- a/magnus-macros/src/typed_data.rs
+++ b/magnus-macros/src/typed_data.rs
@@ -132,8 +132,12 @@ pub fn expand_derive_typed_data(input: DeriveInput) -> TokenStream {
     let tokens = quote! {
         unsafe impl magnus::TypedData for #ident {
             fn class() -> magnus::RClass {
-                use magnus::Module;
-                *magnus::memoize!(magnus::RClass: magnus::RClass::default().funcall("const_get", (#class,)).unwrap())
+                use magnus::{Module, Class, RClass};
+                *magnus::memoize!(RClass: {
+                    let class: RClass = RClass::default().funcall("const_get", (#class,)).unwrap();
+                    class.undef_alloc_func();
+                    class
+                })
             }
 
             fn data_type() -> &'static magnus::DataType {

--- a/src/class.rs
+++ b/src/class.rs
@@ -288,7 +288,9 @@ pub trait Class: Module {
     /// Remove the allocator function of a class.
     ///
     /// Useful for RTypedData, where instances should not be allocated by
-    /// the default allocate function.
+    /// the default allocate function. `#[derive(TypedData)]` and `#[wrap]`
+    /// take care of undefining the allocator function, you do not need
+    /// to use `undef_alloc_func` if you're using one of those.
     ///
     /// # Examples
     ///
@@ -302,9 +304,8 @@ pub trait Class: Module {
     /// let instance = class.new_instance(());
     /// assert_eq!("allocator undefined for Point", instance.err().unwrap().to_string());
     /// ```
-    fn undef_alloc_func(self) -> Self {
-        unsafe { rb_undef_alloc_func(self.as_rb_value()) };
-        self
+    fn undef_alloc_func(self) {
+        unsafe { rb_undef_alloc_func(self.as_rb_value()) }
     }
 }
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -10,7 +10,7 @@ use rb_sys::{
     rb_cMethod, rb_cModule, rb_cNameErrorMesg, rb_cNilClass, rb_cNumeric, rb_cObject, rb_cProc,
     rb_cRandom, rb_cRange, rb_cRational, rb_cRegexp, rb_cStat, rb_cString, rb_cStruct, rb_cSymbol,
     rb_cThread, rb_cTime, rb_cTrueClass, rb_cUnboundMethod, rb_class2name, rb_class_new,
-    rb_class_new_instance, rb_class_superclass, ruby_value_type, VALUE,
+    rb_class_new_instance, rb_class_superclass, rb_undef_alloc_func, ruby_value_type, VALUE,
 };
 
 use crate::{
@@ -283,6 +283,28 @@ pub trait Class: Module {
     /// Return `self` as an [`RClass`].
     fn as_r_class(self) -> RClass {
         RClass::from_value(*self).unwrap()
+    }
+
+    /// Remove the allocator function of a class.
+    ///
+    /// Useful for RTypedData, where instances should not be allocated by
+    /// the default allocate function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::{class, eval, Class};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    /// let class = magnus::define_class("Point", Default::default()).unwrap();
+    ///
+    /// class.undef_alloc_func();
+    ///
+    /// let instance = class.new_instance(());
+    /// assert_eq!("allocator undefined for Point", instance.err().unwrap().to_string());
+    /// ```
+    fn undef_alloc_func(self) -> Self {
+        unsafe { rb_undef_alloc_func(self.as_rb_value()) };
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1606,7 +1606,7 @@
 // * `rb_ulong2num_inline`:
 // * `rb_undef`:
 // * `rb_undefine_finalizer`:
-// * `rb_undef_alloc_func`:
+//! * `rb_undef_alloc_func`: [`Class::undef_alloc_func`]
 // * `rb_undef_method`:
 // * `rb_unexpected_type`:
 // * `RB_UNLIKELY`:

--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -312,10 +312,14 @@ where
     /// # Examples
     ///
     /// ```
-    /// use magnus::{define_class, memoize, RClass};
+    /// use magnus::{define_class, memoize, RClass, Class};
     ///
     /// fn class() -> RClass {
-    ///     *memoize!(RClass: define_class("Foo", Default::default()).unwrap())
+    ///     *memoize!(RClass: {
+    ///       let class = define_class("Foo", Default::default()).unwrap();
+    ///       class.undef_alloc_func();
+    ///       class
+    ///     })
     /// }
     /// ```
     fn class() -> RClass;


### PR DESCRIPTION
Starting with Ruby 3.2, leaving the default allocator function for `T_DATA` will emit a warning:

> warning: undefining the allocator of T_DATA class [...]

This commit adds `RClass::undef_alloc_func` so that users can get rid of that warning.


Given any `T_DATA` will trigger the warning, I think it'd make sense for this to be in the examples and in [the macro implementation](https://github.com/matsadler/magnus/blob/ae792419bed70107d4c930e1f8193272750b9fd2/magnus-macros/src/typed_data.rs#L134-L137). Agreed? If so, happy to create another PR for that.

----


Relevant references:
- [Code in ruby/ruby where this warning is emitted](https://github.com/ruby/ruby/blob/91050d3443956a2841aa91defee0d178a18fc347/gc.c#L3100-L3103)
- [Issue on Ruby's issue tracker](https://bugs.ruby-lang.org/issues/18007)
