### PR TITLE
Do not implement ArgList for &[Value]

### DIFF
--- a/src/try_convert.rs
+++ b/src/try_convert.rs
@@ -745,14 +745,6 @@ pub trait ArgList {
     fn into_arg_list(self) -> Self::Output;
 }
 
-impl<'a> ArgList for &'a [Value] {
-    type Output = &'a [Value];
-
-    fn into_arg_list(self) -> Self::Output {
-        self
-    }
-}
-
 impl ArgList for () {
     type Output = [Value; 0];
 


### PR DESCRIPTION
# Why? 

Currently magnus implements `ArgList` for `&'a [Value]` which means that it's also implemented for `Vec<Value>`. Using `Vec<Value>` is fairly unsafe in my experience, as it's almost impossible to have it behave correctly and match the safety guarantees around `Value`s staying on the stack and not being on the heap. 

This current implementation makes it seem like it's okay to use a `Vec` as an argument, when in most cases people really shouldn't do that. 

# How? 

Delete said implementation. We already have `ArgList` implemented for `[Value; N]` which should cover most cases where the deleted implementation was used. 

# Note for the reviewers

Maybe I'm wrong and I'm missing some context as to why `ArgList` is needed for `&'a [Value]`. If so, please just close this PR.