### PR TITLE
Add conversions for slices into `RArray`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,9 @@ rb-sys-env = "0.1.1"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[profile.dev]
+# Will ensure that the compiler will optimize out any intermediate stack values
+# so they are promoted to the heap. This exposes GC bugs in when using
+# `GC.stress = true`.
+opt-level = 1

--- a/src/r_array.rs
+++ b/src/r_array.rs
@@ -51,7 +51,7 @@ impl RubyHandle {
 
     pub fn ary_new_from_values<T>(&self, slice: &[T]) -> RArray
     where
-        T: ReprValue,
+        T: Into<Value>,
     {
         let ptr = slice.as_ptr() as *const VALUE;
         unsafe {
@@ -388,7 +388,7 @@ impl RArray {
     /// ```
     pub fn from_slice<T>(slice: &[T]) -> Self
     where
-        T: ReprValue,
+        T: Into<Value>,
     {
         get_ruby!().ary_new_from_values(slice)
     }
@@ -1650,6 +1650,24 @@ where
     T: Into<Value>,
 {
     fn from(val: Vec<T>) -> Self {
+        get_ruby!().into_value(val)
+    }
+}
+
+impl<T> IntoValue for &[T]
+where
+    T: Into<Value>,
+{
+    fn into_value(self, handle: &RubyHandle) -> Value {
+        handle.ary_new_from_values(self).into()
+    }
+}
+
+impl<T> From<&[T]> for Value
+where
+    T: Into<Value>,
+{
+    fn from(val: &[T]) -> Self {
         get_ruby!().into_value(val)
     }
 }


### PR DESCRIPTION
### Problem

Currently, it is relatively easy to go from a `Vec<Into<Value>>` to a `RArray` in magnus. unfortunately, in certain situations, this can trigger unsound behavior with the Ruby GC.

Before safely storing a `Value` on the heap (i.e. `Vec`), the value needs to be reachable by the GC. Reachability from the GC means at least one of:

- `Value` is stored on the machine stack
- `Value` is stored in the CPU registers
- `Value` is stored on the heap _and_ the mark bit every time the GC runs

Unfortunately, none of these 3 can be guaranteed when building an intermediary `Vec<Value>`. Here is an example that will reliably trigger a `SIGABRT` when compiling with an `opt-level > 0`.

```rust
use magnus::{eval, RArray, RString, Value};

#[allow(clippy::vec_init_then_push)]
#[test]
pub fn it_induces_a_rb_bug_when_values_arent_on_the_stack() {
    let _cleanup = unsafe { magnus::embed::init() };
    let _: Value = eval!("GC.stress = true").unwrap();

    let mut args: Vec<RString> = Vec::new();

    args.push(RString::new("foo"));
    args.push(RString::new("foo"));
    args.push(RString::new("foo"));

    let array = RArray::from_vec(args);

    assert_eq!("[\"foo\", \"foo\", \"foo\"]", array.inspect());
}

// running 1 test
// <OBJ_INFO:gc_mark_ptr@gc.c:6730> 0x0000000104dd1b70 [0 M    ] T_NONE 
// -e: [BUG] try to mark T_NONE object
// ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin22]
```

This happens because with `opt-level > 0`, LLVM is able to optimize the code such that no intermediary stack values for the `RString` stay live. As such, the values only live on the heap, and with nothing to mark them, the values are unreachable by the GC and reclaimed.

In practice, this behavior is much harder to trigger than in the contrived example since the Ruby GC is far more conservative than it is in `GC.stress` mode. It's also important to note that in practice, this might not result in a `rb_bug`, but instead random `Value`s appearing in the array (since the GC slot will be free). 

### Solution

For the purposes of this PR, I decided to make sound buffering of stack values easier to work with. This way, it's at least as easy to convert as safe stack-buffered arrays as it currently is for vecs.


```rust
let mut args = [*QNIL; 16];

args[0] = RString::new("foo").into();
args[1] = RString::new("bar").into();
args[2] = RString::new("baz").into();

val.funcall("foo", (&args[0..3],))
```


It may be possible to statically ensure safety by modeling the concept of a `Reachable<Value>` using primitives like `Pin` and something to represent `GcMarked<Value>`. However, that would radically change the ergonomics of magnus. Although maybe long-term, static safety is something we can try to make ergonomic without sacrificing ease-of-use.


