### PR TITLE
Add value (de)serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "magnus-macros",
  "rb-sys",
  "rb-sys-env",
+ "serde",
 ]
 
 [[package]]
@@ -210,6 +211,26 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "shell-words"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,11 @@ ruby-static = ["rb-sys/ruby-static"]
 [dependencies]
 magnus-macros = { version = "0.3.0", path = "magnus-macros" }
 rb-sys = { version = "0.9.56", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+serde = { version = "1.0.152", optional = true }
 
 [dev-dependencies]
-magnus = { path = ".", features = ["embed", "rb-sys-interop"] }
+magnus = { path = ".", features = ["embed", "rb-sys-interop", "serde"] }
+serde = { version = "1.0.152", features = ["derive"] }
 
 [build-dependencies]
 rb-sys-env = "0.1.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 //! Rust types for working with Ruby Exceptions and other interrupts.
 
-use std::{any::Any, borrow::Cow, ffi::CString, fmt, mem::transmute, ops::Deref, os::raw::c_int};
+use std::{
+    any::Any, borrow::Cow, error, ffi::CString, fmt, mem::transmute, ops::Deref, os::raw::c_int,
+};
 
 use rb_sys::{
     rb_bug, rb_ensure, rb_errinfo, rb_exc_raise, rb_iter_break, rb_iter_break_value, rb_jump_tag,
@@ -126,6 +128,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl error::Error for Error {}
+
 impl From<Tag> for Error {
     fn from(val: Tag) -> Self {
         Self::Jump(val)
@@ -135,6 +139,20 @@ impl From<Tag> for Error {
 impl From<Exception> for Error {
     fn from(val: Exception) -> Self {
         Self::Exception(val)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::de::Error for Error {
+    fn custom<T: fmt::Display>(message: T) -> Self {
+        Error::new(crate::exception::runtime_error(), message.to_string())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Error for Error {
+    fn custom<T: fmt::Display>(message: T) -> Self {
+        Error::new(crate::exception::runtime_error(), message.to_string())
     }
 }
 

--- a/src/r_bignum.rs
+++ b/src/r_bignum.rs
@@ -124,7 +124,7 @@ impl RBignum {
         get_ruby!().bignum_from_u64(n)
     }
 
-    fn is_negative(self) -> bool {
+    pub(crate) fn is_negative(self) -> bool {
         debug_assert_value!(self);
         unsafe {
             let r_basic = self.r_basic_unchecked();

--- a/src/r_hash.rs
+++ b/src/r_hash.rs
@@ -27,6 +27,7 @@ use crate::{
     exception,
     into_value::IntoValue,
     object::Object,
+    r_array::RArray,
     ruby_handle::RubyHandle,
     try_convert::{TryConvert, TryConvertOwned},
     value::{private, Fixnum, NonZeroValue, ReprValue, Value, QNIL, QUNDEF},
@@ -172,6 +173,14 @@ impl RHash {
     #[cfg_attr(docsrs, doc(cfg(ruby_gte_3_2)))]
     pub fn with_capacity(n: usize) -> Self {
         get_ruby!().with_capacity(n)
+    }
+
+    /// Create a new empty `RHash`. The provided capacity is ignored.
+    ///
+    /// Allows Magnus internals to call `RHash::with_capacity` unconditionally.
+    #[cfg(not(any(ruby_gte_3_2, docsrs)))]
+    pub(crate) fn with_capacity(_: usize) -> Self {
+        get_ruby!().hash_new()
     }
 
     /// Set the value `val` for the key `key`.
@@ -624,6 +633,11 @@ impl RHash {
     /// ```
     pub fn is_empty(self) -> bool {
         self.len() == 0
+    }
+
+    #[cfg_attr(not(feature = "serde"), allow(unused))]
+    pub(crate) fn keys(self) -> Result<RArray, Error> {
+        self.funcall("keys", ())
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,5 @@
+mod de;
+mod ser;
+
+pub use de::deserialize;
+pub use ser::serialize;

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,6 +3,11 @@
 #[cfg(ruby_use_flonum)]
 mod flonum;
 
+#[cfg(feature = "serde")]
+mod de;
+#[cfg(feature = "serde")]
+mod ser;
+
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -17,6 +22,12 @@ use std::{
 
 #[cfg(ruby_use_flonum)]
 pub use flonum::Flonum;
+
+#[cfg(feature = "serde")]
+pub use de::deserialize;
+#[cfg(feature = "serde")]
+pub use ser::serialize;
+
 use rb_sys::{
     rb_any_to_s, rb_block_call, rb_check_funcall, rb_check_id, rb_check_id_cstr,
     rb_check_symbol_cstr, rb_enumeratorize_with_size, rb_eql, rb_equal, rb_funcall_with_block,

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,0 +1,415 @@
+use crate::{Error, Fixnum, RArray, RBignum, RFloat, RHash, RString, Symbol, Value};
+use rb_sys::ruby_value_type;
+use serde::{
+    de::{
+        Deserialize, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,
+        Unexpected, VariantAccess, Visitor,
+    },
+    forward_to_deserialize_any,
+};
+
+/// Deserialize a Ruby [`Value`] to Rust.
+///
+/// See [`crate::value::serialize`] for the expected Ruby formats of various Rust types.
+///
+/// ```
+/// use magnus::{eval, Value, value::deserialize};
+/// use serde::{Deserialize};
+/// # let _cleanup = unsafe { magnus::embed::init() };
+///
+/// #[derive(Deserialize, Debug)]
+/// struct A {
+///     b: B,
+///     c: [i32; 3],
+///     d: Option<D>,
+/// }
+///
+/// #[derive(Deserialize, PartialEq, Debug)]
+/// struct B(u32);
+///
+/// #[derive(Deserialize, PartialEq, Debug)]
+/// enum D {
+///     A { a: String },
+/// }
+///
+/// let a: Value = eval(
+///     r#"
+///     {
+///       b: 1234,
+///       c: [123, -456, 789],
+///       d: {
+///         "A" => { a: "test" }
+///       }
+///     }
+///     "#,
+/// )
+/// .unwrap();
+///
+/// let a: A = deserialize(a).unwrap();
+///
+/// assert_eq!(B(1234), a.b);
+/// assert_eq!([123, -456, 789], a.c);
+/// assert_eq!(
+///     Some(D::A {
+///         a: String::from("test")
+///     }),
+///     a.d
+/// );
+/// ```
+pub fn deserialize<'i, T, U>(value: T) -> Result<U, Error>
+where
+    T: Into<Value>,
+    U: Deserialize<'i>,
+{
+    U::deserialize(Deserializer {
+        value: value.into(),
+    })
+}
+
+struct Deserializer {
+    value: Value,
+}
+
+impl<'i> serde::Deserializer<'i> for Deserializer {
+    type Error = Error;
+
+    fn deserialize_any<T: Visitor<'i>>(self, visitor: T) -> Result<T::Value, Self::Error> {
+        match self.value.rb_type() {
+            ruby_value_type::RUBY_T_NIL => visitor.visit_unit(),
+
+            ruby_value_type::RUBY_T_TRUE | ruby_value_type::RUBY_T_FALSE => {
+                visitor.visit_bool(self.value.to_bool())
+            }
+
+            ruby_value_type::RUBY_T_FIXNUM => {
+                let fixnum = unsafe { Fixnum::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_i64(fixnum.to_i64())
+            }
+
+            ruby_value_type::RUBY_T_BIGNUM => {
+                let bignum = unsafe { RBignum::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                if bignum.is_negative() {
+                    visitor.visit_i64(bignum.to_i64()?)
+                } else {
+                    visitor.visit_u64(bignum.to_u64()?)
+                }
+            }
+
+            ruby_value_type::RUBY_T_FLOAT => {
+                let float = unsafe { RFloat::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_f64(float.to_f64())
+            }
+
+            ruby_value_type::RUBY_T_STRING => {
+                let string = unsafe { RString::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_string(string.to_string()?)
+            }
+
+            ruby_value_type::RUBY_T_SYMBOL => {
+                let symbol = unsafe { Symbol::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_string(symbol.name()?.to_string())
+            }
+
+            ruby_value_type::RUBY_T_ARRAY => {
+                let array = unsafe { RArray::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_seq(ArrayDeserializer::new(&array))
+            }
+
+            ruby_value_type::RUBY_T_HASH => {
+                let hash = unsafe { RHash::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_map(HashDeserializer::new(&hash)?)
+            }
+
+            _ => Err(Error::new(
+                crate::exception::type_error(),
+                format!(
+                    "can't deserialize {}",
+                    unsafe { self.value.classname() }.into_owned()
+                ),
+            )),
+        }
+    }
+
+    fn deserialize_bytes<T>(self, visitor: T) -> Result<T::Value, Error>
+    where
+        T: Visitor<'i>,
+    {
+        visitor.visit_bytes(self.value.try_convert::<String>()?.as_bytes())
+    }
+
+    fn deserialize_byte_buf<T>(self, visitor: T) -> Result<T::Value, Error>
+    where
+        T: Visitor<'i>,
+    {
+        visitor.visit_bytes(self.value.try_convert::<String>()?.as_bytes())
+    }
+
+    fn deserialize_option<T>(self, visitor: T) -> Result<T::Value, Error>
+    where
+        T: Visitor<'i>,
+    {
+        if self.value.is_nil() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_enum<T>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: T,
+    ) -> Result<T::Value, Error>
+    where
+        T: Visitor<'i>,
+    {
+        match self.value.rb_type() {
+            ruby_value_type::RUBY_T_STRING => {
+                let variant = unsafe { RString::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                visitor.visit_enum(EnumDeserializer {
+                    variant: variant.to_string()?,
+                    value: None,
+                })
+            }
+
+            ruby_value_type::RUBY_T_HASH => {
+                let hash = unsafe { RHash::from_rb_value_unchecked(self.value.as_rb_value()) };
+
+                if hash.len() == 1 {
+                    let key: String = hash.keys()?.entry(0)?;
+                    let value = hash.get(key.as_str());
+
+                    visitor.visit_enum(EnumDeserializer {
+                        variant: key,
+                        value,
+                    })
+                } else {
+                    Err(Error::new(
+                        crate::exception::type_error(),
+                        format!("can't deserialize Hash of length {} to Enum", hash.len()),
+                    ))
+                }
+            }
+
+            _ => Err(Error::new(
+                crate::exception::type_error(),
+                format!(
+                    "can't deserialize {} to Enum",
+                    unsafe { self.value.classname() }.into_owned()
+                ),
+            )),
+        }
+    }
+
+    fn deserialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        visitor: T,
+    ) -> Result<T::Value, Error>
+    where
+        T: Visitor<'i>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_ignored_any<T>(self, visitor: T) -> Result<T::Value, Error>
+    where
+        T: Visitor<'i>,
+    {
+        visitor.visit_unit()
+    }
+
+    forward_to_deserialize_any! {
+        <T: Visitor<'i>>
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        unit unit_struct seq tuple tuple_struct map struct identifier
+    }
+}
+
+struct ArrayDeserializer<'i> {
+    array: &'i RArray,
+    index: isize,
+}
+
+impl<'i> ArrayDeserializer<'i> {
+    fn new(array: &'i RArray) -> Self {
+        Self { array, index: 0 }
+    }
+}
+
+impl<'i, 'de> SeqAccess<'de> for ArrayDeserializer<'i> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.index as usize >= self.array.len() {
+            return Ok(None);
+        }
+
+        let value: Value = self.array.entry(self.index)?;
+        self.index += 1;
+
+        seed.deserialize(Deserializer { value }).map(Some)
+    }
+}
+
+struct HashDeserializer<'i> {
+    hash: &'i RHash,
+    keys: RArray,
+    index: isize,
+}
+
+impl<'i> HashDeserializer<'i> {
+    fn new(hash: &'i RHash) -> Result<Self, Error> {
+        Ok(Self {
+            hash,
+            keys: hash.keys()?,
+            index: 0,
+        })
+    }
+}
+
+impl<'i, 'de> MapAccess<'de> for HashDeserializer<'i> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.index as usize >= self.keys.len() {
+            return Ok(None);
+        }
+
+        let key = self.keys.entry(self.index)?;
+
+        seed.deserialize(Deserializer { value: key }).map(Some)
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.index as usize >= self.hash.len() {
+            return Err(Error::new(
+                crate::exception::index_error(),
+                format!(
+                    "index out of range (expected 0...{}, got {})",
+                    self.hash.len(),
+                    self.index,
+                ),
+            ));
+        }
+
+        let key: Value = self.keys.entry(self.index)?;
+        let value: Value = self.hash.aref(key)?;
+        self.index += 1;
+
+        seed.deserialize(Deserializer { value })
+    }
+}
+
+struct EnumDeserializer {
+    variant: String,
+    value: Option<Value>,
+}
+
+impl<'i> EnumAccess<'i> for EnumDeserializer {
+    type Variant = VariantDeserializer;
+    type Error = Error;
+
+    fn variant_seed<T>(self, seed: T) -> Result<(T::Value, Self::Variant), Error>
+    where
+        T: DeserializeSeed<'i>,
+    {
+        let deserializer = VariantDeserializer { value: self.value };
+        seed.deserialize(self.variant.into_deserializer())
+            .map(|value| (value, deserializer))
+    }
+}
+
+struct VariantDeserializer {
+    value: Option<Value>,
+}
+
+impl<'i> VariantAccess<'i> for VariantDeserializer {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        if let Some(value) = self.value {
+            deserialize(value)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'i>,
+    {
+        if let Some(value) = self.value {
+            seed.deserialize(Deserializer { value })
+        } else {
+            Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            ))
+        }
+    }
+
+    fn tuple_variant<T>(self, _len: usize, visitor: T) -> Result<T::Value, Self::Error>
+    where
+        T: Visitor<'i>,
+    {
+        if let Some(value) = self.value {
+            if let Ok(array) = value.try_convert::<RArray>() {
+                visitor.visit_seq(&mut ArrayDeserializer::new(&array))
+            } else {
+                Err(serde::de::Error::invalid_type(
+                    Unexpected::Other(&(unsafe { value.classname() }.to_owned())),
+                    &"tuple variant",
+                ))
+            }
+        } else {
+            Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            ))
+        }
+    }
+
+    fn struct_variant<T>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: T,
+    ) -> Result<T::Value, Self::Error>
+    where
+        T: Visitor<'i>,
+    {
+        if let Some(value) = self.value {
+            if let Ok(hash) = value.try_convert::<RHash>() {
+                visitor.visit_map(&mut HashDeserializer::new(&hash)?)
+            } else {
+                Err(serde::de::Error::invalid_type(
+                    Unexpected::Other(&(unsafe { value.classname() }.to_owned())),
+                    &"struct variant",
+                ))
+            }
+        } else {
+            Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            ))
+        }
+    }
+}

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,0 +1,471 @@
+use crate::{Error, RArray, RHash, RString, Symbol, TryConvert, Value};
+use serde::ser::{
+    Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+    SerializeTupleStruct, SerializeTupleVariant,
+};
+
+/// Serialize Rust data to a Ruby [`Value`].
+///
+/// The most basic Rust types are converted as follows:
+///
+/// | Rust type                 | Ruby value                          |
+/// |---------------------------|-------------------------------------|
+/// | `()`                      | `nil`                               |
+/// | `bool`                    | `true` or `false`                   |
+/// | `i8`, `i16`, `i32`, `i64` | An `Integer`                        |
+/// | `u8`, `u16`, `u32`, `u64` | An `Integer`                        |
+/// | `f32` or `f64`            | A `Float`                           |
+/// | `char`                    | A `String` with UTF-8 encoding      |
+/// | `&str`                    | A `String` with UTF-8 encoding      |
+/// | `String`                  | A `String` with UTF-8 encoding      |
+/// | `&[u8]`                   | A `String` with ASCII-8BIT encoding |
+///
+/// ```
+/// use magnus::{Integer, RString, value::serialize};
+/// # let _cleanup = unsafe { magnus::embed::init() };
+///
+/// let magic: Integer = serialize(&1234).unwrap();
+/// assert_eq!(1234, magic.to_u64().unwrap());
+///
+/// let greeting: RString = serialize("Hello, world!").unwrap();
+/// assert_eq!("Hello, world!", greeting.to_string().unwrap());
+/// ```
+///
+/// ### `Option`
+///
+/// `None` is converted to `nil`. For an `Option<T>`, `Some` is unwrapped and its `T` value is
+/// recursively serialized.
+///
+/// ```
+/// use magnus::{Integer, Value, value::serialize};
+/// # let _cleanup = unsafe { magnus::embed::init() };
+///
+/// let magic: Option<u64> = None;
+/// let magic: Value = serialize(&magic).unwrap();
+/// assert!(magic.is_nil());
+///
+/// let magic: Option<u64> = Some(1234);
+/// let magic: Integer = serialize(&magic).unwrap();
+/// assert_eq!(1234, magic.to_u64().unwrap());
+/// ```
+///
+/// ### Structs
+///
+/// A unit struct (`A` in the example code below) is converted to `nil`.
+///
+/// A newtype struct (`B`) is unwrapped. Its value is recursively serialized.
+///
+/// A tuple struct (`C`) is converted to an `Array`. The `Array` contains the struct's fields,
+/// recursively serialized.
+///
+/// A struct with named fields (`D`) is converted to a `Hash` with the field names as `Symbol`
+/// keys. The field values are recursively serialized.
+///
+/// ```
+/// use magnus::{Integer, RArray, RHash, Symbol, Value, value::serialize};
+/// use serde::Serialize;
+/// # let _cleanup = unsafe { magnus::embed::init() };
+///
+/// #[derive(Serialize)]
+/// struct A;
+///
+/// #[derive(Serialize)]
+/// struct B(u16);
+///
+/// #[derive(Serialize)]
+/// struct C(u16, bool, B);
+///
+/// #[derive(Serialize)]
+/// struct D {
+///     foo: u16,
+///     bar: bool,
+///     baz: B
+/// }
+///
+/// let a: Value = serialize(&A).unwrap();
+/// assert!(a.is_nil());
+///
+/// let b: Integer = serialize(&B(1234)).unwrap();
+/// assert_eq!(1234, b.to_u64().unwrap());
+///
+/// let c: RArray = serialize(&C(1234, false, B(5678))).unwrap();
+/// assert_eq!(3, c.len());
+/// assert_eq!(1234, c.entry(0).unwrap());
+/// assert_eq!(false, c.entry(1).unwrap());
+/// assert_eq!(5678, c.entry(2).unwrap());
+///
+/// let d: RHash = serialize(&D { foo: 1234, bar: false, baz: B(5678) }).unwrap();
+/// assert_eq!(1234, d.lookup(Symbol::new("foo")).unwrap());
+/// assert_eq!(false, d.lookup(Symbol::new("bar")).unwrap());
+/// assert_eq!(5678, d.lookup(Symbol::new("baz")).unwrap());
+/// ```
+///
+/// ### Enums
+///
+/// A unit enum variant (`A::Z` in the example code below) is converted to the name of the
+/// variant as a `String` (`"Z"`).
+///
+/// All other types of enum variants (`A::Y`, `A::X`, `A::W`) are converted to a `Hash` with one
+/// key: the name of the variant as a `String` (`"Y"`', `"X"`, `"W"`).
+///
+/// For a newtype enum variant (`A::Y`), the value keyed by the variant name is the variant's value
+/// recursively serialized.
+///
+/// For a tuple enum variant (`A::X`), the value keyed by the variant name is an `Array` containing
+/// the variant's fields recursively serialized.
+///
+/// For a struct enum variant (`A::W`), the value keyed by the variant name is a `Hash` with the
+/// variant's field names as `Symbol` keys. The field values are recursively serialized.
+///
+/// ```
+/// use magnus::{Integer, RArray, RHash, RString, Symbol, Value, value::serialize};
+/// use serde::Serialize;
+/// # let _cleanup = unsafe { magnus::embed::init() };
+///
+/// #[derive(Serialize)]
+/// enum A {
+///     Z,
+///     Y(u16),
+///     X(u16, bool, Box<A>),
+///     W {
+///         foo: u16,
+///         bar: bool,
+///         baz: Box<A>
+///     }
+/// }
+///
+/// let a: RString = serialize(&A::Z).unwrap();
+/// assert_eq!("Z", a.to_string().unwrap());
+///
+/// let a: RHash = serialize(&A::Y(1234)).unwrap();
+/// assert_eq!(1, a.len());
+/// assert_eq!(1234, a.lookup("Y").unwrap());
+///
+/// let a: RHash = serialize(&A::X(1234, false, Box::new(A::Y(5678)))).unwrap();
+/// let ax: RArray = a.lookup("X").unwrap();
+/// assert_eq!(3, ax.len());
+/// assert_eq!(1234, ax.entry(0).unwrap());
+/// assert_eq!(false, ax.entry(1).unwrap());
+/// assert_eq!(5678, ax.entry::<RHash>(2).unwrap().lookup("Y").unwrap());
+///
+/// let a: RHash = serialize(&A::W { foo: 1234, bar: false, baz: Box::new(A::Y(5678)) }).unwrap();
+/// let aw: RHash = a.lookup("W").unwrap();
+/// assert_eq!(1234, aw.lookup(Symbol::new("foo")).unwrap());
+/// assert_eq!(false, aw.lookup(Symbol::new("bar")).unwrap());
+/// let awbaz: RHash = aw.lookup(Symbol::new("baz")).unwrap();
+/// assert_eq!(5678, awbaz.lookup("Y").unwrap());
+/// ```
+pub fn serialize<T: Serialize + ?Sized, U: TryConvert>(value: &T) -> Result<U, Error> {
+    value.serialize(Serializer)?.try_convert()
+}
+
+struct Serializer;
+
+impl serde::Serializer for Serializer {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = SeqSerializer;
+    type SerializeTuple = SeqSerializer;
+    type SerializeTupleStruct = SeqSerializer;
+    type SerializeTupleVariant = TupleVariantSerializer;
+    type SerializeMap = MapSerializer;
+    type SerializeStruct = StructSerializer;
+    type SerializeStructVariant = StructVariantSerializer;
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(value.into())
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(RString::from_slice(value).into())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(().into())
+    }
+
+    fn serialize_some<T: Serialize + ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(().into())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(().into())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(variant.into())
+    }
+
+    fn serialize_newtype_struct<T: Serialize + ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: Serialize + ?Sized>(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        let hash = RHash::new();
+        hash.aset(variant, value.serialize(self)?)?;
+        Ok(hash.into())
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(SeqSerializer {
+            array: RArray::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Ok(TupleVariantSerializer {
+            variant,
+            array: RArray::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(MapSerializer {
+            hash: RHash::with_capacity(len.unwrap_or(0)),
+            key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(StructSerializer {
+            hash: RHash::with_capacity(len),
+        })
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(StructVariantSerializer {
+            variant,
+            hash: RHash::with_capacity(len),
+        })
+    }
+}
+
+struct SeqSerializer {
+    array: RArray,
+}
+
+impl SerializeSeq for SeqSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
+        self.array.push(value.serialize(Serializer)?)
+    }
+
+    fn end(self) -> Result<Self::Ok, self::Error> {
+        Ok(self.array.into())
+    }
+}
+
+impl SerializeTuple for SeqSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
+        <Self as SerializeSeq>::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, self::Error> {
+        <Self as SerializeSeq>::end(self)
+    }
+}
+
+impl SerializeTupleStruct for SeqSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
+        <Self as SerializeSeq>::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Self::Ok, self::Error> {
+        <Self as SerializeSeq>::end(self)
+    }
+}
+
+struct TupleVariantSerializer {
+    variant: &'static str,
+    array: RArray,
+}
+
+impl SerializeTupleVariant for TupleVariantSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
+        self.array.push(value.serialize(Serializer)?)
+    }
+
+    fn end(self) -> Result<Self::Ok, self::Error> {
+        let hash = RHash::with_capacity(1);
+        hash.aset(self.variant, self.array)?;
+        Ok(hash.into())
+    }
+}
+
+struct MapSerializer {
+    hash: RHash,
+    key: Option<Value>,
+}
+
+impl SerializeMap for MapSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_key<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
+        self.key = Some(value.serialize(Serializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), Self::Error> {
+        self.hash
+            .aset(self.key.unwrap(), value.serialize(Serializer)?)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.hash.into())
+    }
+}
+
+struct StructSerializer {
+    hash: RHash,
+}
+
+impl SerializeStruct for StructSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: Serialize + ?Sized>(
+        &mut self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        self.hash
+            .aset(Symbol::new(name), value.serialize(Serializer)?)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.hash.into())
+    }
+}
+
+struct StructVariantSerializer {
+    variant: &'static str,
+    hash: RHash,
+}
+
+impl SerializeStructVariant for StructVariantSerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T: Serialize + ?Sized>(
+        &mut self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error> {
+        self.hash
+            .aset(Symbol::new(name), value.serialize(Serializer)?)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let hash = RHash::with_capacity(1);
+        hash.aset(self.variant, self.hash)?;
+        Ok(hash.into())
+    }
+}

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,0 +1,46 @@
+use magnus::{eval, value::deserialize, Value};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct A {
+    b: B,
+    c: [i32; 3],
+    d: Option<D>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct B(u32);
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+enum D {
+    A { a: String },
+}
+
+#[test]
+fn it_deserializes_a_ruby_value_to_a_rust_type() {
+    let _cleanup = unsafe { magnus::embed::init() };
+
+    let a_as_hash: Value = eval(
+        r#"
+        {
+          b: 1234,
+          c: [123, -456, 789],
+          d: {
+            "A" => { a: "test" }
+          }
+        }
+        "#,
+    )
+    .unwrap();
+
+    let a: A = deserialize(a_as_hash).unwrap();
+
+    assert_eq!(B(1234), a.b);
+    assert_eq!([123, -456, 789], a.c);
+    assert_eq!(
+        Some(D::A {
+            a: String::from("test")
+        }),
+        a.d
+    );
+}

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,0 +1,46 @@
+use magnus::{value::serialize, Integer, RArray, RHash, RString, Symbol};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct A {
+    b: B,
+    c: [i32; 3],
+    d: Option<D>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct B(u32);
+
+#[derive(Serialize, Deserialize)]
+enum D {
+    A { a: String },
+}
+
+#[test]
+fn it_serializes_a_rust_type_to_a_ruby_value() {
+    let _cleanup = unsafe { magnus::embed::init() };
+
+    let a = A {
+        b: B(1234),
+        c: [123, -456, 789],
+        d: Some(D::A {
+            a: String::from("test"),
+        }),
+    };
+
+    let a_as_hash = serialize::<A, RHash>(&a).unwrap();
+
+    let b: Integer = a_as_hash.lookup(Symbol::new("b")).unwrap();
+    assert_eq!(1234, b.to_u32().unwrap());
+
+    let c: RArray = a_as_hash.lookup(Symbol::new("c")).unwrap();
+    assert_eq!(3, c.len());
+    assert_eq!(123, c.entry::<Integer>(0).unwrap().to_i32().unwrap());
+    assert_eq!(-456, c.entry::<Integer>(1).unwrap().to_i32().unwrap());
+    assert_eq!(789, c.entry::<Integer>(2).unwrap().to_i32().unwrap());
+
+    let d: RHash = a_as_hash.lookup(Symbol::new("d")).unwrap();
+    let d: RHash = d.lookup("A").unwrap();
+    let d_a: RString = d.lookup(Symbol::new("a")).unwrap();
+    assert_eq!("test", d_a.to_string().unwrap());
+}


### PR DESCRIPTION
[napi](https://github.com/napi-rs/napi-rs) is a library that provides Rust-Node.js bindings. It provides the function [`to_js_value`](https://docs.rs/napi/latest/napi/bindgen_prelude/struct.Env.html#method.to_js_value), enabled by a feature flag, which uses [Serde](https://serde.rs) to “serialize” any Rust type into a JS value. A complementary function, [`from_js_value`](https://docs.rs/napi/latest/napi/bindgen_prelude/struct.Env.html#method.from_js_value), deserializes properly-formatted JS values back into Rust types. We can do the same thing for Ruby.

Here’s why I’m interested in this feature. I’m working on [Classmate](https://github.com/georgeclaghorn/classmate), a library of Ruby bindings to the [Lightning CSS](https://lightningcss.dev) Rust crate. On Node.js, Lightning CSS offers a powerful [custom transforms](https://lightningcss.dev/transforms.html) feature. It traverses a parse tree for a stylesheet and calls user-provided functions for each node. The provided functions can return replacement nodes. Under the hood, the syntax nodes are converted from Rust structs to JS objects using napi `to_js_value`. The returned substitute nodes are converted from JS objects back to Rust structs using `from_js_value`.

I would like to implement an equivalent feature in Classmate. I’d very much prefer not to have to create a Typed Data wrapper or build my own `Hash` for every type of syntax node. There are quite a lot, because CSS is a complex language, and they change frequently as Lightning CSS gains support for new CSS features.

This PR introduces a new Magnus feature flag named `serde`. When the `serde` feature is enabled, two new functions are exposed: `magnus::value::serialize` and `magnus::value::deserialize`. `serialize` takes any Rust type that implements `serde::Serialize` and converts it into a Ruby approximation. `deserialize` turns a Ruby value back into a Rust type that implements `serde::Deserialize`. See the included docs for `serialize` and `deserialize` to understand how they translate between Rust and Ruby.