### PR TITLE
Add `error::Result<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `RMatch::nth_defined`, `RMatch::nth_match`, `RMatch::backref_number`,
   `RMatch::matched`, `RMatch::pre`, `RMatch::post`, and `RMatch::last`
 - `RBignum::is_positive`/`is_negative`.
-- `new`, `num`, and `den` for `RRational`, plus `rationalize` and 
+- `new`, `num`, and `den` for `RRational`, plus `rationalize` and
   `rationalize_with_prec` for `Float`.
 - `value::Id::new` added to replace `value::Id::from`.
 - `TypedData::class_for` can be implemented to customise the class on a case by
@@ -27,6 +27,7 @@
   variant when wrapping enums in a Ruby object.
 - `Value::funcall_public` calls a public method, returning an error for a
   private or protected method.
+- `error::Result<T>` is shorthand for `std::result::Result<T, Error>`.
 
 ### Changed
 - When converting Ruby values to `RArray` (or `Vec<T>`, `[T; 1]`, or `(T,)`),

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,9 @@ impl RubyHandle {
     }
 }
 
+/// Shorthand for `std::result::Result<T, Error>`.
+pub type Result<T> = std::result::Result<T, Error>;
+
 /// A Rust representation of a Ruby `Exception` or other interrupt.
 #[derive(Debug)]
 pub enum Error {
@@ -206,7 +209,7 @@ impl fmt::Display for Tag {
 /// All functions exposed by magnus that call Ruby in a way that may raise
 /// already use this internally, but this is provided for anyone calling
 /// the Ruby C API directly.
-pub(crate) fn protect<F, T>(func: F) -> Result<T, Error>
+pub(crate) fn protect<F, T>(func: F) -> Result<T>
 where
     F: FnOnce() -> T,
     T: ReprValue,


### PR DESCRIPTION
Shorthand for `std::result::Result<T, Error>`. I haven't updated existing instances of `Result<_, Error>` in the library except where necessary.