### PR TITLE
Add `Value::funcall_public`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - `value::Id::new` added to replace `value::Id::from`.
 - `TypedData::class_for` can be implemented to customise the class on a case by
   case basis when wrapping Rust data in a Ruby object.
+- `Value::funcall_public` calls a public method, returning an error for a private
+  or protected method.
 
 ### Changed
 - When converting Ruby values to `RArray` (or `Vec<T>`, `[T; 1]`, or `(T,)`),


### PR DESCRIPTION
Allow calling a method only if it’s public, returning an error if it’s private or protected.