### PR TITLE
Default `TypedData` as `wb_protected` when there is no mark function

### DIFF
--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -256,7 +256,7 @@ where
         if self.free_immediately {
             flags |= RUBY_TYPED_FREE_IMMEDIATELY as VALUE;
         }
-        if self.wb_protected {
+        if self.wb_protected || !self.mark {
             flags |= RUBY_TYPED_WB_PROTECTED as VALUE;
         }
         #[cfg(ruby_gte_3_0)]


### PR DESCRIPTION
If there is no mark function, then we assume there are no references to Ruby objects. As such, we can avoid inserting GC write barriers.

See: https://github.com/ruby/ruby/pull/7255