### PR TITLE
add ruby String to rust Byte Collection conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,7 @@ dependencies = [
 name = "magnus"
 version = "0.5.0"
 dependencies = [
+ "bytes",
  "magnus",
  "magnus-macros",
  "rb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ exclude = ["examples/rust_blank/ext/rust_blank", "examples/custom_exception_ruby
 embed = ["rb-sys/link-ruby"]
 rb-sys-interop = []
 ruby-static = ["rb-sys/ruby-static"]
+bytes-crate = ["bytes"]
 
 [dependencies]
 magnus-macros = { version = "0.4.0", path = "magnus-macros" }
 rb-sys = { version = "0.9.56", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+bytes = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytes-crate = ["bytes"]
 [dependencies]
 magnus-macros = { version = "0.4.0", path = "magnus-macros" }
 rb-sys = { version = "0.9.56", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
-bytes = { version = "1.4.0", optional = true }
+bytes = { version = "1", optional = true }
 
 [dev-dependencies]
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ types will get the same kind of `ArgumentError` or `TypeError` they are used to
 seeing from Ruby's built in methods.
 
 Defining a function (with no Ruby `self` argument):
+
 ```rust
 fn fib(n: usize) -> usize {
     match n {
@@ -39,6 +40,7 @@ magnus::define_global_function("fib", magnus::function!(fib, 1));
 ```
 
 Defining a method (with a Ruby `self` argument):
+
 ```rust
 fn is_blank(rb_self: String) -> bool {
     !rb_self.contains(|c: char| !c.is_whitespace())
@@ -143,6 +145,7 @@ Ruby extensions must be built as dynamic system libraries, this can be done by
 setting the `crate-type` attribute in your `Cargo.toml`.
 
 **`Cargo.toml`**
+
 ```toml
 [lib]
 crate-type = ["cdylib"]
@@ -157,6 +160,7 @@ Rust functions to Ruby methods. Use the `#[magnus::init]` attribute to mark
 your init function so it can be correctly exposed to Ruby.
 
 **`src/lib.rs`**
+
 ```rust
 use magnus::{define_global_function, function};
 
@@ -194,6 +198,7 @@ this file during the compilation process, and it will generate a `Makefile` in
 the `ext` directory. See the [`rb_sys` gem] for more information.
 
 **`ext/my_example_gem/extconf.rb`**
+
 ```ruby
 require "mkmf"
 require "rb_sys/mkmf"
@@ -207,6 +212,7 @@ Running `rake compile` will place the extension at
 load from Ruby like so:
 
 **`lib/my_example_gem.rb`**
+
 ```ruby
 require_relative "my_example_gem/my_example_gem"
 ```
@@ -225,6 +231,7 @@ magnus, but it will compile and run properly.
 To call Ruby from a Rust program, enable the `embed` feature:
 
 **`Cargo.toml`**
+
 ```toml
 [dependencies]
 magnus = { version = "0.4", features = ["embed"] }
@@ -236,6 +243,7 @@ returns must not be dropped until you are done with Ruby. `init` can not be
 called more than once.
 
 **`src/main.rs`**
+
 ```rust
 use magnus::{embed, eval};
 
@@ -264,51 +272,53 @@ documentation for the full list of types.
 
 See `magnus::TryConvert` for more details.
 
-| Rust function argument                            | accepted from Ruby                                    |
-|---------------------------------------------------|-----------------------------------------|
-| `i8`,`i16`,`i32`,`i64`,`isize`, `magnus::Integer` | `Integer`, `#to_int`                    |
-| `u8`,`u16`,`u32`,`u64`,`usize`                    | `Integer`, `#to_int`                    |
-| `f32`,`f64`, `magnus::Float`                      | `Float`, `Numeric`                      |
-| `String`, `PathBuf`, `char`, `magnus::RString`    | `String`, `#to_str`                     |
-| `magnus::Symbol`                                  | `Symbol`, `#to_sym`                     |
-| `bool`                                            | any object                              |
-| `magnus::Range`                                   | `Range`                                 |
-| `magnus::Encoding`, `magnus::RbEncoding`          | `Encoding`, encoding name as a string   |
-| `Option<T>`                                       | `T` or `nil`                            |
-| `(T, U)`, `(T, U, V)`, etc                        | `[T, U]`, `[T, U, V]`, etc, `#to_ary`   |
-| `[T; N]`                                          | `[T]`, `#to_ary`                        |
-| `magnus::RArray`                                  | `Array`, `#to_ary`                      |
-| `magnus::RHash`                                   | `Hash`, `#to_hash`                      |
-| `magnus::Value`                                   | any object                              |
-| `Vec<T>`*                                         | `[T]`, `#to_ary`                        |
-| `HashMap<K, V>`*                                  | `{K => V}`, `#to_hash`                  |
-| `&T`, `typed_data::Obj<T>` where `T: TypedData`** | instance of `<T as TypedData>::class()` |
+| Rust function argument                                               | accepted from Ruby                      |
+| -------------------------------------------------------------------- | --------------------------------------- |
+| `i8`,`i16`,`i32`,`i64`,`isize`, `magnus::Integer`                    | `Integer`, `#to_int`                    |
+| `u8`,`u16`,`u32`,`u64`,`usize`                                       | `Integer`, `#to_int`                    |
+| `f32`,`f64`, `magnus::Float`                                         | `Float`, `Numeric`                      |
+| `String`, `PathBuf`, `char`, `magnus::RString`, `bytes::Bytes`\*\*\* | `String`, `#to_str`                     |
+| `magnus::Symbol`                                                     | `Symbol`, `#to_sym`                     |
+| `bool`                                                               | any object                              |
+| `magnus::Range`                                                      | `Range`                                 |
+| `magnus::Encoding`, `magnus::RbEncoding`                             | `Encoding`, encoding name as a string   |
+| `Option<T>`                                                          | `T` or `nil`                            |
+| `(T, U)`, `(T, U, V)`, etc                                           | `[T, U]`, `[T, U, V]`, etc, `#to_ary`   |
+| `[T; N]`                                                             | `[T]`, `#to_ary`                        |
+| `magnus::RArray`                                                     | `Array`, `#to_ary`                      |
+| `magnus::RHash`                                                      | `Hash`, `#to_hash`                      |
+| `magnus::Value`                                                      | any object                              |
+| `Vec<T>`\*                                                           | `[T]`, `#to_ary`                        |
+| `HashMap<K, V>`\*                                                    | `{K => V}`, `#to_hash`                  |
+| `&T`, `typed_data::Obj<T>` where `T: TypedData`\*\*                  | instance of `<T as TypedData>::class()` |
 
 \* when converting to `Vec` and `HashMap` the types of `T`/`K`,`V` must be native Rust types.
 
-\** see the `wrap` macro.
+\*\* see the `wrap` macro.
+
+\*\*\* when the bytes-crate feature is enabled
 
 ### Rust returning / passing values to Ruby
 
 See `magnus::IntoValue` for more details, plus `magnus::method::ReturnValue`
 and `magnus::ArgList` for some additional details.
 
-| returned from Rust / calling Ruby from Rust       | received in Ruby                        |
-|---------------------------------------------------|-----------------------------------------|
-| `i8`,`i16`,`i32`,`i64`,`isize`                    | `Integer`                               |
-| `u8`,`u16`,`u32`,`u64`,`usize`                    | `Integer`                               |
-| `f32`, `f64`                                      | `Float`                                 |
-| `String`, `&str`, `char`, `&Path`, `PathBuf`      | `String`                                |
-| `bool`                                            | `true`/`false`                          |
-| `()`                                              | `nil`                                   |
-| `Range`, `RangeFrom`, `RangeTo`, `RangeInclusive` | `Range`                                 |
-| `Option<T>`                                       | `T` or `nil`                            |
-| `Result<T, magnus::Error>` (return only)          | `T` or raises error                     |
-| `(T, U)`, `(T, U, V)`, etc, `[T; N]`, `Vec<T>`    | `Array`                                 |
-| `HashMap<K, V>`                                   | `Hash`                                  |
-| `T`, `typed_data::Obj<T>` where `T: TypedData`**  | instance of `<T as TypedData>::class()` |
+| returned from Rust / calling Ruby from Rust        | received in Ruby                        |
+| -------------------------------------------------- | --------------------------------------- |
+| `i8`,`i16`,`i32`,`i64`,`isize`                     | `Integer`                               |
+| `u8`,`u16`,`u32`,`u64`,`usize`                     | `Integer`                               |
+| `f32`, `f64`                                       | `Float`                                 |
+| `String`, `&str`, `char`, `&Path`, `PathBuf`       | `String`                                |
+| `bool`                                             | `true`/`false`                          |
+| `()`                                               | `nil`                                   |
+| `Range`, `RangeFrom`, `RangeTo`, `RangeInclusive`  | `Range`                                 |
+| `Option<T>`                                        | `T` or `nil`                            |
+| `Result<T, magnus::Error>` (return only)           | `T` or raises error                     |
+| `(T, U)`, `(T, U, V)`, etc, `[T; N]`, `Vec<T>`     | `Array`                                 |
+| `HashMap<K, V>`                                    | `Hash`                                  |
+| `T`, `typed_data::Obj<T>` where `T: TypedData`\*\* | instance of `<T as TypedData>::class()` |
 
-\** see the `wrap` macro.
+\*\* see the `wrap` macro.
 
 ### Conversions via Serde
 

--- a/src/r_string.rs
+++ b/src/r_string.rs
@@ -900,6 +900,24 @@ impl RString {
             .map_err(|e| Error::new(exception::encoding_error(), format!("{}", e)))
     }
 
+    /// Returns `self` as an owned Rust `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::RString;
+    /// use bytes::Bytes;
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// let s = RString::new("example");
+    /// assert_eq!(s.to_bytes(), Bytes::from("example"));
+    /// ```
+    #[cfg(feature = "bytes-crate")]
+    pub fn to_bytes(self) -> bytes::Bytes {
+        let vec = unsafe { self.as_slice().to_vec() };
+        vec.into()
+    }
+
     /// Converts `self` to a [`char`]. Errors if the string is more than one
     /// character or can not be encoded as UTF-8.
     ///

--- a/src/r_string.rs
+++ b/src/r_string.rs
@@ -912,6 +912,7 @@ impl RString {
     /// let s = RString::new("example");
     /// assert_eq!(s.to_bytes(), Bytes::from("example"));
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "bytes-crate")))]
     #[cfg(feature = "bytes-crate")]
     pub fn to_bytes(self) -> bytes::Bytes {
         let vec = unsafe { self.as_slice().to_vec() };
@@ -1533,6 +1534,20 @@ unsafe impl IntoValueFromNative for &str {}
 impl From<&str> for Value {
     fn from(val: &str) -> Self {
         val.into_value()
+    }
+}
+
+#[cfg(feature = "bytes-crate")]
+impl From<bytes::Bytes> for Value {
+    fn from(val: bytes::Bytes) -> Self {
+        val.into_value()
+    }
+}
+
+#[cfg(feature = "bytes-crate")]
+impl IntoValue for bytes::Bytes {
+    fn into_value_with(self, handle: &RubyHandle) -> Value {
+        handle.str_from_slice(self.as_ref()).into()
     }
 }
 

--- a/src/try_convert.rs
+++ b/src/try_convert.rs
@@ -167,6 +167,17 @@ impl TryConvert for String {
 }
 impl TryConvertOwned for String {}
 
+#[cfg(feature = "bytes-crate")]
+impl TryConvert for bytes::Bytes {
+    fn try_convert(val: Value) -> Result<bytes::Bytes, Error> {
+        debug_assert_value!(val);
+        Ok(RString::try_convert(val)?.to_bytes())
+    }
+}
+
+#[cfg(feature = "bytes-crate")]
+impl TryConvertOwned for bytes::Bytes {}
+
 impl TryConvert for char {
     fn try_convert(val: Value) -> Result<Self, Error> {
         debug_assert_value!(val);

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,0 +1,10 @@
+use magnus::{eval, RString};
+
+#[test]
+#[cfg(feature = "bytes-crate")]
+fn it_converts_to_bytes() {
+    let _cleanup = unsafe { magnus::embed::init() };
+
+    let s: RString = unsafe { eval("[0,0,0].pack('c*')").unwrap() };
+    assert_eq!(bytes::Bytes::from_static(&[0, 0, 0]), s.to_bytes());
+}


### PR DESCRIPTION
i Added support for converting a ruby String into a rust byte collection

In ruby the main way to represent some bytes is with a string, (see File.read or Base64.strict_decode64). and the current way to accept such
a string with magnus is by receiving a RString and calling `.as\_slice().as\_vec()` which is unsafe, this creates safe interface to receive bytes from ruby.

I've decided to use the Bytes crate since it seems to be rust communty's prefered way of dealing with collections of bytes and made the inclusion of it a non defaulted feature
