### PR TITLE
Fix a typo in the deprecated message

### DIFF
--- a/src/r_string.rs
+++ b/src/r_string.rs
@@ -982,7 +982,7 @@ impl RString {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.5.0", note = "please use use `buf_append` instead")]
+    #[deprecated(since = "0.5.0", note = "please use `buf_append` instead")]
     pub fn append(self, other: Self) -> Result<(), Error> {
         self.buf_append(other)
     }


### PR DESCRIPTION
Just removed redundant `use`.