### PR TITLE
Fix unused import warning

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -512,7 +512,7 @@ mod private {
 /// [`function`](crate::function!) macros for converting functions to an
 /// implementor of this trait.
 ///
-/// This trait is implimented for the following function signatures:
+/// This trait is implemented for the following function signatures:
 ///
 /// | Arity | Signature                                                    |
 /// |-------|--------------------------------------------------------------|

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,8 +1,8 @@
-use magnus::{eval, RString};
-
 #[test]
 #[cfg(feature = "bytes-crate")]
 fn it_converts_to_bytes() {
+    use magnus::{eval, RString};
+
     let _cleanup = unsafe { magnus::embed::init() };
 
     let s: RString = unsafe { eval("[0,0,0].pack('c*')").unwrap() };


### PR DESCRIPTION
## Problem

Without this change, I would get the following warning when running `cargo test`

```
warning: unused imports: `RString`, `eval`
 --> tests/bytes.rs:1:14
  |
1 | use magnus::{eval, RString};
  |              ^^^^  ^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `magnus` (test "bytes") generated 1 warning
```

## Solution

The `use` was only needed when the "bytes-crate" feature is enabled, so I moved the `use` statement inside the feature conditional function that uses it.

---

I've also included an unrelated commit that fixes a typo in a comment.