### PR TITLE
`DataTypeFunctions::compact`: borrow `self` mutably

### DIFF
--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -118,7 +118,7 @@ where
     ///
     /// This function **must not** panic. The process will abort if this
     /// function panics.
-    fn compact(&self) {}
+    fn compact(&mut self) {}
 
     /// Extern wrapper for `free`. Don't define or call.
     ///
@@ -173,7 +173,7 @@ where
     /// This function must not panic.
     #[doc(hidden)]
     unsafe extern "C" fn extern_compact(ptr: *mut c_void) {
-        if let Err(e) = catch_unwind(|| Self::compact(&*(ptr as *mut Self))) {
+        if let Err(e) = catch_unwind(|| Self::compact(&mut *(ptr as *mut Self))) {
             bug_from_panic(e, "panic in DataTypeFunctions::compact")
         }
     }


### PR DESCRIPTION
The docs for this method say:

> If your type contains any Ruby values that have been marked as moveable you must update them in this function.

We can't update values in `self` if it’s borrowed immutably.