### PR TITLE
Make magnus::Error impl std::error::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -198,6 +198,8 @@ impl Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {


### PR DESCRIPTION
So it can be used with other error handling crates: thiserror, anyhow, etc.