### PR TITLE
Add scaffolding for `Fiber`

### DIFF
--- a/src/cont.rs
+++ b/src/cont.rs
@@ -22,7 +22,7 @@ impl Fiber {
     /// # Examples
     ///
     /// ```
-    /// use magnus::{fiber::Fiber, eval, Value};
+    /// use magnus::{cont::Fiber, eval, Value};
     /// # let _cleanup = unsafe { magnus::embed::init() };
     ///
     /// let val: Value = eval("Fiber.new { :foo }").unwrap();
@@ -46,7 +46,7 @@ impl Fiber {
     /// # Examples
     ///
     /// ```
-    /// use magnus::{fiber::Fiber, eval, Value};
+    /// use magnus::{cont::Fiber, eval, Value};
     /// # let _cleanup = unsafe { magnus::embed::init() };
     ///
     /// let val: Value = eval("Fiber.new { :foo }").unwrap();

--- a/src/cont.rs
+++ b/src/cont.rs
@@ -1,0 +1,108 @@
+//! Types and functions for working with Ruby fibers.
+
+use std::fmt;
+
+use rb_sys::{rb_fiber_alive_p, rb_obj_is_fiber, Qtrue, VALUE};
+
+use crate::{
+    value::{private, NonZeroValue, ReprValue},
+    Error, IntoValue, Object, Ruby, TryConvert, Value,
+};
+
+/// See the [`ReprValue`] and [`Object`] traits for additional methods
+/// available on this type. See [`Ruby`](Ruby#proc) for methods to create a
+/// `Proc`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct Fiber(NonZeroValue);
+
+impl Fiber {
+    /// Return `Some(Fiber)` if `val` is a `Fiber`, `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::{fiber::Fiber, eval, Value};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// let val: Value = eval("Fiber.new { :foo }").unwrap();
+    /// assert!(Fiber::from_value(val).is_some());
+    ///
+    /// let val: Value = eval("1 + 2").unwrap();
+    /// assert!(Fiber::from_value(val).is_none());
+    /// ```
+    #[inline]
+    pub fn from_value(val: Value) -> Option<Self> {
+        let val = val.as_rb_value();
+        unsafe {
+            Value::new(rb_obj_is_fiber(val))
+                .to_bool()
+                .then(|| Self::from_rb_value_unchecked(val))
+        }
+    }
+
+    /// Check whether the fiber is alive and can be resumed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use magnus::{fiber::Fiber, eval, Value};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// let val: Value = eval("Fiber.new { :foo }").unwrap();
+    /// let fiber = Fiber::from_value(val).unwrap();
+    /// assert!(fiber.is_alive());
+    ///
+    /// let val: Value = eval("Fiber.new { :bar }.tap(&:resume)").unwrap();
+    /// let fiber = Fiber::from_value(val).unwrap();
+    /// assert!(!fiber.is_alive());
+    /// ```
+    pub fn is_alive(self) -> bool {
+        unsafe { rb_fiber_alive_p(private::ReprValue::as_rb_value(self)) == Qtrue.into() }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_rb_value_unchecked(val: VALUE) -> Self {
+        Self(NonZeroValue::new_unchecked(Value::new(val)))
+    }
+}
+
+impl fmt::Display for Fiber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", unsafe {
+            private::ReprValue::to_s_infallible(self)
+        })
+    }
+}
+
+impl fmt::Debug for Fiber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inspect())
+    }
+}
+
+impl IntoValue for Fiber {
+    fn into_value_with(self, _: &Ruby) -> Value {
+        self.0.get()
+    }
+}
+
+impl TryConvert for Fiber {
+    fn try_convert(val: Value) -> Result<Self, Error> {
+        match Self::from_value(val) {
+            Some(v) => Ok(v),
+            None => Err(Error::new(
+                Ruby::get_with(val).exception_type_error(),
+                format!("no implicit conversion of {} into Class", unsafe {
+                    val.classname()
+                },),
+            )),
+        }
+    }
+}
+
+impl Object for Fiber {}
+
+unsafe impl private::ReprValue for Fiber {}
+
+impl ReprValue for Fiber {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,7 @@
 // * `rb_fd_term`:
 // * `rb_fd_zero`:
 // * `rb_feature_provided`:
-// * `rb_fiber_alive_p`:
+//! * `rb_fiber_alive_p`: : [`cont::Fiber::is_alive`].
 // * `rb_fiber_current`:
 // * `rb_fiber_new`:
 // * `rb_fiber_raise`:
@@ -1794,6 +1794,7 @@ mod api;
 mod binding;
 pub mod block;
 pub mod class;
+pub mod cont;
 #[cfg(feature = "embed")]
 #[cfg_attr(docsrs, doc(cfg(feature = "embed")))]
 pub mod embed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1794,8 +1794,6 @@ mod api;
 mod binding;
 pub mod block;
 pub mod class;
-#[cfg(any(ruby_gte_3_0, docsrs))]
-#[cfg_attr(docsrs, doc(cfg(ruby_gte_3_0)))]
 pub mod cont;
 #[cfg(feature = "embed")]
 #[cfg_attr(docsrs, doc(cfg(feature = "embed")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1794,6 +1794,8 @@ mod api;
 mod binding;
 pub mod block;
 pub mod class;
+#[cfg(any(ruby_gte_3_0, docsrs))]
+#[cfg_attr(docsrs, doc(cfg(ruby_gte_3_0)))]
 pub mod cont;
 #[cfg(feature = "embed")]
 #[cfg_attr(docsrs, doc(cfg(feature = "embed")))]


### PR DESCRIPTION
Sets up the basic scaffolding for fiber. Can add the other methods later (`Fiber::resume`, etc).