### PR TITLE
Add `funcall_kw` and `new_instance_kw` methods

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -12,14 +12,13 @@ use rb_sys::{
     rb_cInteger, rb_cMatch, rb_cMethod, rb_cModule, rb_cNameErrorMesg, rb_cNilClass, rb_cNumeric,
     rb_cObject, rb_cProc, rb_cRandom, rb_cRange, rb_cRational, rb_cRegexp, rb_cStat, rb_cString,
     rb_cStruct, rb_cSymbol, rb_cThread, rb_cTime, rb_cTrueClass, rb_cUnboundMethod, rb_class2name,
-    rb_class_new, rb_class_new_instance, rb_class_new_instance_kw, rb_class_superclass,
-    rb_define_alloc_func, rb_get_alloc_func, rb_obj_alloc, rb_undef_alloc_func, ruby_value_type,
-    VALUE,
+    rb_class_new, rb_class_new_instance_kw, rb_class_superclass, rb_define_alloc_func,
+    rb_get_alloc_func, rb_obj_alloc, rb_undef_alloc_func, ruby_value_type, VALUE,
 };
 
 use crate::{
     error::{protect, Error},
-    into_value::{ArgList, IntoValue, KwArgList},
+    into_value::{kw_splat, ArgList, IntoValue},
     module::Module,
     object::Object,
     try_convert::TryConvert,
@@ -151,6 +150,33 @@ pub trait Class: Module {
     /// ```
     ///
     /// ```
+    /// use magnus::{class, eval, kwargs, prelude::*, RClass, RHash};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// let cls: RClass = eval!(
+    ///     r#"
+    ///     class Foo
+    ///       def initialize(bar, baz:)
+    ///         @bar = bar
+    ///         @baz = baz
+    ///       end
+    ///
+    ///       attr_reader(:bar, :baz)
+    ///     end
+    ///
+    ///     Object.const_get(:Foo)
+    /// "#
+    /// )
+    /// .unwrap();
+    /// let instance = cls.new_instance((1, kwargs!("baz" => 2))).unwrap();
+    /// assert!(instance.is_kind_of(cls));
+    /// let bar: i32 = instance.funcall("bar", ()).unwrap();
+    /// assert_eq!(bar, 1);
+    /// let baz: i32 = instance.funcall("baz", ()).unwrap();
+    /// assert_eq!(baz, 2);
+    /// ```
+    ///
+    /// ```
     /// use magnus::{exception, prelude::*};
     /// # let _cleanup = unsafe { magnus::embed::init() };
     ///
@@ -159,42 +185,9 @@ pub trait Class: Module {
     ///     .unwrap();
     /// assert!(s.is_kind_of(exception::standard_error()));
     /// ```
-    fn new_instance<T>(self, args: T) -> Result<Self::Instance, Error>
-    where
-        T: ArgList;
-
-    /// Create a new object, an instance of `self`, passing the keyword
-    /// arguments `args` to the initialiser.
-    ///
-    /// # Examples
     ///
     /// ```
-    /// use magnus::{class, eval, prelude::*, RClass, RHash};
-    /// # let _cleanup = unsafe { magnus::embed::init() };
-    ///
-    /// let cls: RClass = eval!(
-    ///     r#"
-    ///     class Foo
-    ///       def initialize(bar:)
-    ///         @bar = bar
-    ///       end
-    ///
-    ///       attr_reader(:bar)
-    ///     end
-    ///
-    ///     Object.const_get(:Foo)
-    /// "#
-    /// )
-    /// .unwrap();
-    /// let kwargs = eval::<RHash>(r#"{bar: "val"}"#).unwrap();
-    /// let instance = cls.new_instance_kw(kwargs).unwrap();
-    /// assert!(instance.is_kind_of(cls));
-    /// let bar: String = instance.funcall("bar", ()).unwrap();
-    /// assert_eq!(bar, "val");
-    /// ```
-    ///
-    /// ```
-    /// use magnus::{eval, ExceptionClass, prelude::*, RHash};
+    /// use magnus::{eval, ExceptionClass, kwargs, prelude::*, RHash};
     /// # let _cleanup = unsafe { magnus::embed::init() };
     ///
     /// let exc: ExceptionClass = eval!(
@@ -208,15 +201,14 @@ pub trait Class: Module {
     ///     Object.const_get(:MyError)
     /// "#
     /// ).unwrap();
-    /// let kwargs = eval::<RHash>(r#"{message: "bang!"}"#).unwrap();
-    /// let s = exc.new_instance_kw(kwargs).unwrap();
+    /// let s = exc.new_instance((kwargs!("message" => "bang!"),)).unwrap();
     /// assert!(s.is_kind_of(exc));
     /// let message: String = s.funcall("message", ()).unwrap();
     /// assert_eq!(message, "bang!");
     /// ```
-    fn new_instance_kw<T>(self, args: T) -> Result<Self::Instance, Error>
+    fn new_instance<T>(self, args: T) -> Result<Self::Instance, Error>
     where
-        T: KwArgList;
+        T: ArgList;
 
     /// Create a new object, an instance of `self`, without calling the class's
     /// `initialize` method.
@@ -496,24 +488,7 @@ impl Class for RClass {
     where
         T: ArgList,
     {
-        let args = args.into_arg_list_with(&Ruby::get_with(self));
-        let slice = args.as_ref();
-        unsafe {
-            protect(|| {
-                Value::new(rb_class_new_instance(
-                    slice.len() as c_int,
-                    slice.as_ptr() as *const VALUE,
-                    self.as_rb_value(),
-                ))
-            })
-        }
-    }
-
-    fn new_instance_kw<T>(self, args: T) -> Result<Self::Instance, Error>
-    where
-        T: KwArgList,
-    {
-        let kw_splat = args.kw_splat();
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&Ruby::get_with(self));
         let slice = args.as_ref();
         unsafe {

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -21,7 +21,7 @@ use rb_sys::{
 use crate::{
     class::{Class, RClass},
     error::Error,
-    into_value::{ArgList, IntoValue, KwArgList},
+    into_value::{ArgList, IntoValue},
     module::Module,
     object::Object,
     r_array::RArray,
@@ -232,15 +232,6 @@ impl Class for ExceptionClass {
     {
         self.as_r_class()
             .new_instance(args)
-            .map(|ins| unsafe { Exception::from_value_unchecked(ins) })
-    }
-
-    fn new_instance_kw<T>(self, args: T) -> Result<Self::Instance, Error>
-    where
-        T: KwArgList,
-    {
-        self.as_r_class()
-            .new_instance_kw(args)
             .map(|ins| unsafe { Exception::from_value_unchecked(ins) })
     }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -21,7 +21,7 @@ use rb_sys::{
 use crate::{
     class::{Class, RClass},
     error::Error,
-    into_value::{ArgList, IntoValue},
+    into_value::{ArgList, IntoValue, KwArgList},
     module::Module,
     object::Object,
     r_array::RArray,
@@ -232,6 +232,15 @@ impl Class for ExceptionClass {
     {
         self.as_r_class()
             .new_instance(args)
+            .map(|ins| unsafe { Exception::from_value_unchecked(ins) })
+    }
+
+    fn new_instance_kw<T>(self, args: T) -> Result<Self::Instance, Error>
+    where
+        T: KwArgList,
+    {
+        self.as_r_class()
+            .new_instance_kw(args)
             .map(|ins| unsafe { Exception::from_value_unchecked(ins) })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1847,7 +1847,7 @@ use ::rb_sys::rb_require;
 #[cfg(ruby_gte_2_7)]
 use ::rb_sys::rb_require_string;
 use ::rb_sys::{
-    rb_backref_get, rb_call_super, rb_current_receiver, rb_define_class, rb_define_global_const,
+    rb_backref_get, rb_call_super_kw, rb_current_receiver, rb_define_class, rb_define_global_const,
     rb_define_global_function, rb_define_module, rb_define_variable, rb_errinfo,
     rb_eval_string_protect, rb_set_errinfo, VALUE,
 };
@@ -1863,7 +1863,7 @@ pub use crate::{
     exception::{Exception, ExceptionClass},
     float::Float,
     integer::Integer,
-    into_value::{ArgList, IntoValue, IntoValueFromNative, RArrayArgList},
+    into_value::{ArgList, IntoValue, IntoValueFromNative, KwArgs, RArrayArgList},
     module::{Attr, Module, RModule},
     numeric::Numeric,
     object::Object,
@@ -2270,12 +2270,14 @@ impl Ruby {
         T: TryConvert,
     {
         unsafe {
+            let kw_splat = into_value::kw_splat(&args);
             let args = args.into_arg_list_with(self);
             let slice = args.as_ref();
             protect(|| {
-                Value::new(rb_call_super(
+                Value::new(rb_call_super_kw(
                     slice.len() as c_int,
                     slice.as_ptr() as *const VALUE,
+                    kw_splat as c_int,
                 ))
             })
             .and_then(TryConvert::try_convert)

--- a/src/value.rs
+++ b/src/value.rs
@@ -23,9 +23,9 @@ use std::{
 #[cfg(ruby_use_flonum)]
 pub use flonum::Flonum;
 use rb_sys::{
-    rb_any_to_s, rb_block_call, rb_check_funcall, rb_check_id, rb_check_id_cstr,
-    rb_check_symbol_cstr, rb_enumeratorize_with_size, rb_eql, rb_equal, rb_funcall_with_block,
-    rb_funcallv, rb_funcallv_kw, rb_funcallv_public, rb_gc_register_address,
+    rb_any_to_s, rb_block_call_kw, rb_check_funcall_kw, rb_check_id, rb_check_id_cstr,
+    rb_check_symbol_cstr, rb_enumeratorize_with_size_kw, rb_eql, rb_equal,
+    rb_funcall_with_block_kw, rb_funcallv_kw, rb_funcallv_public_kw, rb_gc_register_address,
     rb_gc_unregister_address, rb_hash, rb_id2name, rb_id2sym, rb_inspect, rb_intern3, rb_ll2inum,
     rb_obj_as_string, rb_obj_classname, rb_obj_freeze, rb_obj_is_kind_of, rb_obj_respond_to,
     rb_sym2id, rb_ull2inum, ruby_fl_type, ruby_special_consts, ruby_value_type, RBasic, ID, VALUE,
@@ -45,7 +45,7 @@ use crate::{
     error::{protect, Error},
     gc,
     integer::{Integer, IntegerType},
-    into_value::{ArgList, IntoValue, IntoValueFromNative, KwArgList},
+    into_value::{kw_splat, ArgList, IntoValue, IntoValueFromNative},
     method::{Block, BlockReturn},
     module::Module,
     numeric::Numeric,
@@ -1114,6 +1114,27 @@ pub trait ReprValue: private::ReprValue {
     /// let result: String = values.funcall("join", (" & ",)).unwrap();
     /// assert_eq!(result, "foo & 1 & bar");
     /// ```
+    ///
+    /// ```
+    /// use magnus::{eval, kwargs, prelude::*, RHash, RObject, Symbol};
+    /// # let _cleanup = unsafe { magnus::embed::init() };
+    ///
+    /// let object: RObject = eval!(
+    ///     r#"
+    ///     class Adder
+    ///       def add(a, b, c:)
+    ///         a + b + c
+    ///       end
+    ///     end
+    ///
+    ///     Adder.new
+    /// "#
+    /// )
+    /// .unwrap();
+    ///
+    /// let result: i32 = object.funcall("add", (1, 2, kwargs!("c" => 3))).unwrap();
+    /// assert_eq!(result, 6);
+    /// ```
     fn funcall<M, A, T>(self, method: M, args: A) -> Result<T, Error>
     where
         M: IntoId,
@@ -1122,59 +1143,7 @@ pub trait ReprValue: private::ReprValue {
     {
         let handle = Ruby::get_with(self);
         let id = method.into_id_with(&handle);
-        let args = args.into_arg_list_with(&handle);
-        let slice = args.as_ref();
-        unsafe {
-            protect(|| {
-                Value::new(rb_funcallv(
-                    self.as_rb_value(),
-                    id.as_rb_id(),
-                    slice.len() as c_int,
-                    slice.as_ptr() as *const VALUE,
-                ))
-            })
-            .and_then(TryConvert::try_convert)
-        }
-    }
-
-    /// Call the method named `method` on `self` with `args`.
-    ///
-    /// Returns `Ok(T)` if the method returns without error and the return
-    /// value converts to a `T`, or returns `Err` if the method raises or the
-    /// conversion fails.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use magnus::{eval, prelude::*, RHash, RObject, Symbol};
-    /// # let _cleanup = unsafe { magnus::embed::init() };
-    ///
-    /// let object: RObject = eval!(
-    ///     r#"
-    ///     class Foo
-    ///       def bar(b:)
-    ///         b
-    ///       end
-    ///     end
-    ///
-    ///     Foo.new
-    /// "#
-    /// )
-    /// .unwrap();
-    /// let kwargs = eval::<RHash>(r#"{b: "val"}"#).unwrap();
-    ///
-    /// let result: String = object.funcall_kw("bar", kwargs).unwrap();
-    /// assert_eq!(result, "val");
-    /// ```
-    fn funcall_kw<M, A, T>(self, method: M, args: A) -> Result<T, Error>
-    where
-        M: IntoId,
-        A: KwArgList,
-        T: TryConvert,
-    {
-        let handle = Ruby::get_with(self);
-        let id = method.into_id_with(&handle);
-        let kw_splat = args.kw_splat();
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&handle);
         let slice = args.as_ref();
         unsafe {
@@ -1236,15 +1205,17 @@ pub trait ReprValue: private::ReprValue {
     {
         let handle = Ruby::get_with(self);
         let id = method.into_id_with(&handle);
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&handle);
         let slice = args.as_ref();
         unsafe {
             protect(|| {
-                Value::new(rb_funcallv_public(
+                Value::new(rb_funcallv_public_kw(
                     self.as_rb_value(),
                     id.as_rb_id(),
                     slice.len() as c_int,
                     slice.as_ptr() as *const VALUE,
+                    kw_splat as c_int,
                 ))
             })
             .and_then(TryConvert::try_convert)
@@ -1278,15 +1249,17 @@ pub trait ReprValue: private::ReprValue {
     {
         let handle = Ruby::get_with(self);
         let id = method.into_id_with(&handle);
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&handle);
         let slice = args.as_ref();
         unsafe {
             let result = protect(|| {
-                Value::new(rb_check_funcall(
+                Value::new(rb_check_funcall_kw(
                     self.as_rb_value(),
                     id.as_rb_id(),
                     slice.len() as c_int,
                     slice.as_ptr() as *const VALUE,
+                    kw_splat as c_int,
                 ))
             });
             match result {
@@ -1323,16 +1296,18 @@ pub trait ReprValue: private::ReprValue {
     {
         let handle = Ruby::get_with(self);
         let id = method.into_id_with(&handle);
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&handle);
         let slice = args.as_ref();
         unsafe {
             protect(|| {
-                Value::new(rb_funcall_with_block(
+                Value::new(rb_funcall_with_block_kw(
                     self.as_rb_value(),
                     id.as_rb_id(),
                     slice.len() as c_int,
                     slice.as_ptr() as *const VALUE,
                     block.as_rb_value(),
+                    kw_splat as c_int,
                 ))
             })
             .and_then(TryConvert::try_convert)
@@ -1400,6 +1375,7 @@ pub trait ReprValue: private::ReprValue {
 
         let handle = Ruby::get_with(self);
         let id = method.into_id_with(&handle);
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&handle);
         let slice = args.as_ref();
         let call_func =
@@ -1409,13 +1385,14 @@ pub trait ReprValue: private::ReprValue {
 
         protect(|| unsafe {
             #[allow(clippy::fn_to_numeric_cast)]
-            Value::new(rb_block_call(
+            Value::new(rb_block_call_kw(
                 self.as_rb_value(),
                 id.as_rb_id(),
                 slice.len() as c_int,
                 slice.as_ptr() as *const VALUE,
                 Some(call_func),
                 block as VALUE,
+                kw_splat as c_int,
             ))
         })
         .and_then(TryConvert::try_convert)
@@ -1609,15 +1586,17 @@ pub trait ReprValue: private::ReprValue {
         A: ArgList,
     {
         let handle = Ruby::get_with(self);
+        let kw_splat = kw_splat(&args);
         let args = args.into_arg_list_with(&handle);
         let slice = args.as_ref();
         unsafe {
-            Enumerator::from_rb_value_unchecked(rb_enumeratorize_with_size(
+            Enumerator::from_rb_value_unchecked(rb_enumeratorize_with_size_kw(
                 self.as_rb_value(),
                 method.into_symbol_with(&handle).as_rb_value(),
                 slice.len() as c_int,
                 slice.as_ptr() as *const VALUE,
                 None,
+                kw_splat as c_int,
             ))
         }
     }


### PR DESCRIPTION
This PR adds support for function calls and object initialization with keyword arguments.

The trait `KwArgList` is quite similar to `ArgList`, with the key difference being an additional `contains_kw_args` method indicating if the final value in the slice is an `RHash` intended for use as kwargs. I only implemented it for `RHash`. It should be possible to implement for the value arrays and tuples that `ArgList` is implemented for, but it isn't obvious to me how to distinguish between, for example, a `[Value; 3]` where the final element is an `RHash` intended to be used as kwargs and a `[Value; 3]` where that is not the case.