### PR TITLE
Backport rb-sys stable-api to 0.5.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,17 +22,12 @@ jobs:
           - "3.2"
           - head
         rustup-toolchain:
-          - "1.51"
+          - "1.60"
           - stable
         include:
           - os: windows-latest
             ruby-version: mswin
             rustup-toolchain: stable
-        exclude:
-          - os: macos-latest
-            rustup-toolchain: "1.51"
-          - os: windows-latest
-            ruby-version: head
 
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +36,7 @@ jobs:
         with:
           rustup-toolchain: ${{ matrix.rustup-toolchain }}
           ruby-version: ${{ matrix.ruby-version }}
-          cache-version: v2
+          cache-version: v3
           bundler-cache: true
           cargo-cache: true
           cargo-cache-extra-path: |
@@ -52,15 +47,19 @@ jobs:
 
       - name: Example gem tests (blank?)
         working-directory: examples/rust_blank
+        env:
+          RB_SYS_STABLE_API_COMPILED_FALLBACK: "1"
         run: bundle exec rake test
 
       - name: Example gem tests (custom exception defined in Ruby)
-        if: matrix.ruby-version != 'head'
+        env:
+          RB_SYS_STABLE_API_COMPILED_FALLBACK: "1"
         working-directory: examples/custom_exception_ruby
         run: bundle exec rake test
 
       - name: Example gem tests (custom exception defined in Rust)
-        if: matrix.ruby-version != 'head'
+        env:
+          RB_SYS_STABLE_API_COMPILED_FALLBACK: "1"
         working-directory: examples/custom_exception_rust
         run: bundle exec rake test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 
 ### Security
 
+## [0.5.5] - 2023-08-11
+### Changed
+- Integrated the `rb-sys/stable-api` feature to fix compatibility issues with
+ruby-head. This has the following caveats:
+  * The minimum supported version of Rust (MSRV) is now 1.60.
+  * Ruby 2.6 and older will require the `rb-sys/stable-api-compiled-fallback`
+    feature to be enabled.
+
 ## [0.5.4] - 2023-06-07
 ### Changed
 - `try_convert` module is now public so that `TryConvertOwned` can be

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bytes",
  "magnus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "86b8f9420f797f2d9e935edf629310eb938a0d839f984e25327f3c7eed22300c"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -28,13 +28,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bytes"
@@ -88,9 +89,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -120,7 +121,7 @@ dependencies = [
  "magnus",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -153,36 +154,36 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rb-sys"
-version = "0.9.71"
+version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156bfedced1e236600bcaad538477097ff2ed5c6b474e411d15b791e1d24c0f1"
+checksum = "a57240b308b155b09dce81e32829966a99f52d1088b45957e4283e526c5317a1"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.71"
+version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb2e4a32cbc290b543a74567072ad24b708aff7bb5dde5a68d5690379cd7938"
+checksum = "f24ce877a4c5d07f06f6aa6fec3ac95e4b357b9f73b0f5445d8cbb7266d410e8"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -190,7 +191,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -201,9 +202,21 @@ checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -212,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -246,10 +259,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.8"
+name = "syn"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,15 @@ bytes-crate = ["bytes"]
 
 [dependencies]
 magnus-macros = { version = "0.4.0", path = "magnus-macros" }
-rb-sys = { version = "0.9.56", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types"] }
+rb-sys = { version = "~0.9.81", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types", "stable-api"] }
 bytes = { version = "1", optional = true }
 
 [dev-dependencies]
+rb-sys = { version = "~0.9.81", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types", "stable-api", "stable-api-compiled-fallback"] }
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }
 
 [build-dependencies]
-rb-sys-env = "0.1.1"
+rb-sys-env = "0.1.2"
 
 [lib]
 doc-scrape-examples = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magnus"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Mat Sadler <mat@sourcetagsandcodes.com>"]
 edition = "2018"
 resolver = "2"
@@ -15,7 +15,11 @@ exclude = [".github", ".gitignore"]
 
 [workspace]
 members = ["magnus-macros"]
-exclude = ["examples/rust_blank/ext/rust_blank", "examples/custom_exception_ruby/ext/ahriman", "examples/custom_exception_rust/ext/ahriman"]
+exclude = [
+  "examples/rust_blank/ext/rust_blank",
+  "examples/custom_exception_ruby/ext/ahriman",
+  "examples/custom_exception_rust/ext/ahriman",
+]
 
 [features]
 embed = ["rb-sys/link-ruby"]
@@ -25,11 +29,20 @@ bytes-crate = ["bytes"]
 
 [dependencies]
 magnus-macros = { version = "0.4.0", path = "magnus-macros" }
-rb-sys = { version = "~0.9.81", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types", "stable-api"] }
+rb-sys = { version = "~0.9.81", default-features = false, features = [
+  "bindgen-rbimpls",
+  "bindgen-deprecated-types",
+  "stable-api",
+] }
 bytes = { version = "1", optional = true }
 
 [dev-dependencies]
-rb-sys = { version = "~0.9.81", default-features = false, features = ["bindgen-rbimpls", "bindgen-deprecated-types", "stable-api", "stable-api-compiled-fallback"] }
+rb-sys = { version = "~0.9.81", default-features = false, features = [
+  "bindgen-rbimpls",
+  "bindgen-deprecated-types",
+  "stable-api",
+  "stable-api-compiled-fallback",
+] }
 magnus = { path = ".", features = ["embed", "rb-sys-interop"] }
 
 [build-dependencies]

--- a/src/r_array.rs
+++ b/src/r_array.rs
@@ -1,19 +1,14 @@
 use std::{
-    cmp::Ordering, convert::TryInto, fmt, iter::FromIterator, ops::Deref, os::raw::c_long,
-    ptr::NonNull, slice,
+    cmp::Ordering, convert::TryInto, fmt, iter::FromIterator, ops::Deref, os::raw::c_long, slice,
 };
 
-#[cfg(ruby_gte_3_0)]
-use rb_sys::ruby_rarray_consts::RARRAY_EMBED_LEN_SHIFT;
-#[cfg(ruby_lt_3_0)]
-use rb_sys::ruby_rarray_flags::RARRAY_EMBED_LEN_SHIFT;
 use rb_sys::{
     self, rb_ary_assoc, rb_ary_cat, rb_ary_clear, rb_ary_cmp, rb_ary_concat, rb_ary_delete,
     rb_ary_delete_at, rb_ary_entry, rb_ary_includes, rb_ary_join, rb_ary_new, rb_ary_new_capa,
     rb_ary_new_from_values, rb_ary_plus, rb_ary_pop, rb_ary_push, rb_ary_rassoc, rb_ary_replace,
     rb_ary_resize, rb_ary_reverse, rb_ary_rotate, rb_ary_shared_with_p, rb_ary_shift,
     rb_ary_sort_bang, rb_ary_store, rb_ary_subseq, rb_ary_to_ary, rb_ary_unshift,
-    rb_check_array_type, ruby_rarray_flags, ruby_value_type, VALUE,
+    rb_check_array_type, ruby_value_type, RARRAY_CONST_PTR, RARRAY_LEN, VALUE,
 };
 
 use crate::{
@@ -92,11 +87,6 @@ impl RArray {
     #[inline]
     pub(crate) unsafe fn from_rb_value_unchecked(val: VALUE) -> Self {
         Self(NonZeroValue::new_unchecked(Value::new(val)))
-    }
-
-    fn as_internal(self) -> NonNull<rb_sys::RArray> {
-        // safe as inner value is NonZero
-        unsafe { NonNull::new_unchecked(self.0.get().as_rb_value() as *mut _) }
     }
 
     /// Create a new empty `RArray`.
@@ -221,18 +211,7 @@ impl RArray {
     /// ```
     pub fn len(self) -> usize {
         debug_assert_value!(self);
-        unsafe {
-            let r_basic = self.r_basic_unchecked();
-            let flags = r_basic.as_ref().flags;
-            if (flags & ruby_rarray_flags::RARRAY_EMBED_FLAG as VALUE) != 0 {
-                let len = (flags >> RARRAY_EMBED_LEN_SHIFT as VALUE)
-                    & (ruby_rarray_flags::RARRAY_EMBED_LEN_MASK as VALUE
-                        >> RARRAY_EMBED_LEN_SHIFT as VALUE);
-                len.try_into().unwrap()
-            } else {
-                self.as_internal().as_ref().as_.heap.len.try_into().unwrap()
-            }
-        }
+        unsafe { RARRAY_LEN(self.as_rb_value()) as usize }
     }
 
     /// Return whether self contains any entries or not.
@@ -764,20 +743,9 @@ impl RArray {
 
     pub(crate) unsafe fn as_slice_unconstrained<'a>(self) -> &'a [Value] {
         debug_assert_value!(self);
-        let r_basic = self.r_basic_unchecked();
-        let flags = r_basic.as_ref().flags;
-        if (flags & ruby_rarray_flags::RARRAY_EMBED_FLAG as VALUE) != 0 {
-            let len = (flags >> RARRAY_EMBED_LEN_SHIFT as VALUE)
-                & (ruby_rarray_flags::RARRAY_EMBED_LEN_MASK as VALUE
-                    >> RARRAY_EMBED_LEN_SHIFT as VALUE);
-            slice::from_raw_parts(
-                &self.as_internal().as_ref().as_.ary as *const VALUE as *const Value,
-                len as usize,
-            )
-        } else {
-            let h = self.as_internal().as_ref().as_.heap;
-            slice::from_raw_parts(h.ptr as *const Value, h.len as usize)
-        }
+        let ptr = RARRAY_CONST_PTR(self.as_rb_value());
+        let len = RARRAY_LEN(self.as_rb_value());
+        slice::from_raw_parts(ptr as *const Value, len as _)
     }
 
     /// Convert `self` to a Rust vector of `T`s. Errors if converting any

--- a/src/r_string.rs
+++ b/src/r_string.rs
@@ -10,23 +10,18 @@ use std::{
     ops::Deref,
     os::raw::{c_char, c_long},
     path::{Path, PathBuf},
-    ptr::{self, NonNull},
-    slice, str,
+    ptr, slice, str,
 };
 
 #[cfg(ruby_gte_3_0)]
 use rb_sys::rb_str_to_interned_str;
-#[cfg(all(ruby_gte_3_0, ruby_lt_3_2))]
-use rb_sys::ruby_rstring_consts::RSTRING_EMBED_LEN_SHIFT;
-#[cfg(ruby_lt_3_0)]
-use rb_sys::ruby_rstring_flags::RSTRING_EMBED_LEN_SHIFT;
 use rb_sys::{
     self, rb_enc_str_coderange, rb_enc_str_new, rb_str_buf_append, rb_str_buf_new, rb_str_capacity,
     rb_str_cat, rb_str_cmp, rb_str_comparable, rb_str_conv_enc, rb_str_drop_bytes, rb_str_dump,
     rb_str_ellipsize, rb_str_new, rb_str_new_frozen, rb_str_new_shared, rb_str_offset, rb_str_plus,
     rb_str_replace, rb_str_scrub, rb_str_shared_replace, rb_str_split, rb_str_strlen, rb_str_times,
     rb_str_to_str, rb_str_update, rb_utf8_str_new, rb_utf8_str_new_static, ruby_coderange_type,
-    ruby_rstring_flags, ruby_value_type, VALUE,
+    ruby_rstring_flags, ruby_value_type, RSTRING_LEN, RSTRING_PTR, VALUE,
 };
 
 use crate::{
@@ -142,11 +137,6 @@ impl RString {
     #[inline]
     pub(crate) unsafe fn from_rb_value_unchecked(val: VALUE) -> Self {
         Self(NonZeroValue::new_unchecked(Value::new(val)))
-    }
-
-    fn as_internal(self) -> NonNull<rb_sys::RString> {
-        // safe as inner value is NonZero
-        unsafe { NonNull::new_unchecked(self.0.get().as_rb_value() as *mut _) }
     }
 
     /// Create a new Ruby string from the Rust string `s`.
@@ -433,25 +423,10 @@ impl RString {
     }
 
     unsafe fn as_slice_unconstrained<'a>(self) -> &'a [u8] {
-        #[cfg(ruby_gte_3_1)]
-        unsafe fn embedded_ary_ptr(rstring: RString) -> *const u8 {
-            &rstring.as_internal().as_ref().as_.embed.ary as *const _ as *const u8
-        }
-
-        #[cfg(ruby_lt_3_1)]
-        unsafe fn embedded_ary_ptr(rstring: RString) -> *const u8 {
-            &rstring.as_internal().as_ref().as_.ary as *const _ as *const u8
-        }
-
         debug_assert_value!(self);
-        let r_basic = self.r_basic_unchecked();
-        let f = r_basic.as_ref().flags;
-        if (f & ruby_rstring_flags::RSTRING_NOEMBED as VALUE) != 0 {
-            let h = self.as_internal().as_ref().as_.heap;
-            slice::from_raw_parts(h.ptr as *const u8, self.len())
-        } else {
-            slice::from_raw_parts(embedded_ary_ptr(self), self.len())
-        }
+        let ptr = RSTRING_PTR(self.as_rb_value());
+        let len = RSTRING_LEN(self.as_rb_value());
+        slice::from_raw_parts(ptr as *const u8, len as _)
     }
 
     /// Return an iterator over `self`'s codepoints.
@@ -1277,38 +1252,9 @@ impl RString {
     /// let s = RString::new("🦀 Hello, Ferris");
     /// assert_eq!(s.len(), 18);
     /// ```
-    #[cfg(ruby_gte_3_3)]
     pub fn len(self) -> usize {
         debug_assert_value!(self);
-        unsafe { self.as_internal().as_ref().len as usize }
-    }
-
-    /// Returns the number of bytes in `self`.
-    ///
-    /// See also [`length`](RString::length).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use magnus::{eval, RString};
-    /// # let _cleanup = unsafe { magnus::embed::init() };
-    ///
-    /// let s = RString::new("🦀 Hello, Ferris");
-    /// assert_eq!(s.len(), 18);
-    /// ```
-    #[cfg(ruby_lte_3_2)]
-    pub fn len(self) -> usize {
-        debug_assert_value!(self);
-        unsafe {
-            let r_basic = self.r_basic_unchecked();
-            let f = r_basic.as_ref().flags;
-            if (f & ruby_rstring_flags::RSTRING_NOEMBED as VALUE) != 0 {
-                let h = self.as_internal().as_ref().as_.heap;
-                h.len as usize
-            } else {
-                embed_len(self, f) as usize
-            }
-        }
+        unsafe { RSTRING_LEN(self.as_rb_value()) as usize }
     }
 
     /// Returns the number of characters in `self`.
@@ -1439,18 +1385,6 @@ impl RString {
         let delim = CString::new(delim).unwrap();
         unsafe { RArray::from_rb_value_unchecked(rb_str_split(self.as_rb_value(), delim.as_ptr())) }
     }
-}
-
-#[cfg(ruby_3_2)]
-unsafe fn embed_len(value: RString, _: VALUE) -> c_long {
-    value.as_internal().as_ref().as_.embed.len
-}
-
-#[cfg(ruby_lt_3_2)]
-unsafe fn embed_len(_: RString, mut f: VALUE) -> VALUE {
-    f &= ruby_rstring_flags::RSTRING_EMBED_LEN_MASK as VALUE;
-    f >>= RSTRING_EMBED_LEN_SHIFT as VALUE;
-    f
 }
 
 impl Deref for RString {


### PR DESCRIPTION
We have a bunch of gems that are all relying on a personal fork for these changes, and I'm trying to untangle it all. Backporting these (optional) compiled C fallbacks and publishing a 0.5.5 would make things work again and ease a ton of my (and a bunch of other Ruby rustaceans) pains ❤️ 