### PR TITLE
Expose Time API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1842,7 +1842,7 @@ pub mod rb_sys;
 pub mod scan_args;
 pub mod symbol;
 mod thread;
-mod time;
+pub mod time;
 pub mod try_convert;
 pub mod typed_data;
 pub mod value;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,5 @@
+//! Types for working with Ruby’s Time class.
+
 use std::{
     fmt,
     time::{Duration, SystemTime},


### PR DESCRIPTION
This PR exposes the Time API. I've noticed we mention `magnus::Time` [here](https://github.com/matsadler/magnus?tab=readme-ov-file#rust-functions-accepting-values-from-ruby) so it seems like it's our intention :)