### PR TITLE
Add TryConvertOwned for TypedData references

### DIFF
--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -37,7 +37,7 @@ use crate::{
     object::Object,
     r_typed_data::RTypedData,
     scan_args::{get_kwargs, scan_args},
-    try_convert::TryConvert,
+    try_convert::{TryConvert, TryConvertOwned},
     value::{
         private::{self, ReprValue as _},
         ReprValue, Value,
@@ -520,6 +520,8 @@ where
         }
     }
 }
+
+unsafe impl<T> TryConvertOwned for &T where T: TypedData {}
 
 impl<T> IntoValue for T
 where


### PR DESCRIPTION
Hi, this PR adds supports for storing `TypedData` references in `Vec` (mentioned a few years ago in #34).

I think it'd be convenient for function arguments. This would allow users to do:

```rust
fn hello(value: Vec<&Point>) {
    ...
}
```

rather than:

```rust
use magnus::error::Result as RbResult;

fn hello(value: RArray) -> RbResult<()> {
    let value = value.into_iter().map(|v| <&Point>::try_convert(v)).collect::<RbResult<Vec<_>>>()?;
    ...
}
```

(wanted to see if it's something you'd consider before running CI)
