### PR TITLE
Update wrap and TypedData documentation

### DIFF
--- a/examples/mut_point.rs
+++ b/examples/mut_point.rs
@@ -1,12 +1,34 @@
 use std::cell::RefCell;
 
-use magnus::{function, method, prelude::*, wrap};
+use magnus::{function, method, prelude::*, wrap, Error, Ruby};
 
 struct Point {
     x: isize,
     y: isize,
 }
-
+/// The `wrap` macro wraps a Rust type in Ruby, enabling seamless integration.
+/// Magnus uses two Ruby API functions to manage the struct:
+/// - `rb_data_typed_object_wrap`
+/// - `rb_check_typeddata`
+///
+/// # Mutability
+///
+/// Ruby's garbage collector (GC) manages memory for wrapped objects. This prevents using `&mut` references
+/// because Rust requires them to be unique, while Ruby GC may move objects unpredictably. To address this, you can use
+/// [`RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) to enable interior mutability.
+///
+/// # Error Handling
+///
+/// Use [`magnus::Error`](https://docs.rs/magnus/latest/magnus/struct.Error.html) to propagate errors to Ruby.
+/// For example, you can raise a Ruby exception from Rust using Ruby's predefined exception classes.
+///
+/// The syntax for methods like `set_x` differs slightly from typical Rust struct methods because it uses the
+/// [`method!` macro](https://docs.rs/magnus/latest/magnus/macro.method.html):
+/// - The first parameter, `ruby`, gives access to Ruby's runtime.
+/// - The second parameter, `rb_self`, is the Ruby object being called.
+///
+/// @see [`DataTypeFunctions`](https://docs.rs/magnus/latest/magnus/derive.DataTypeFunctions.html)
+/// @see [`TypedData`](https://docs.rs/magnus/latest/magnus/derive.TypedData.html)
 #[wrap(class = "Point")]
 struct MutPoint(RefCell<Point>);
 
@@ -19,8 +41,15 @@ impl MutPoint {
         self.0.borrow().x
     }
 
-    fn set_x(&self, val: isize) {
-        self.0.borrow_mut().x = val;
+    /// Setter for the x coordinate, with validation
+    ///
+    /// Ensures `x` is positive and raises a Ruby `ArgumentError` if the condition is not met.
+    fn set_x(ruby: &Ruby, rb_self: &Self, i: i32) -> Result<(), Error> {
+        if i <= 0 {
+            return Err(Error::new(ruby.exception_arg_error(), "x must be positive"));
+        }
+        rb_self.0.borrow_mut().x = i as isize;
+        Ok(())
     }
 
     fn y(&self) -> isize {

--- a/examples/mut_point.rs
+++ b/examples/mut_point.rs
@@ -6,29 +6,37 @@ struct Point {
     x: isize,
     y: isize,
 }
-/// The `wrap` macro wraps a Rust type in Ruby, enabling seamless integration.
-/// Magnus uses two Ruby API functions to manage the struct:
-/// - `rb_data_typed_object_wrap`
-/// - `rb_check_typeddata`
-///
-/// # Mutability
-///
-/// Ruby's garbage collector (GC) manages memory for wrapped objects. This prevents using `&mut` references
-/// because Rust requires them to be unique, while Ruby GC may move objects unpredictably. To address this, you can use
-/// [`RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) to enable interior mutability.
-///
-/// # Error Handling
-///
-/// Use [`magnus::Error`](https://docs.rs/magnus/latest/magnus/struct.Error.html) to propagate errors to Ruby.
-/// For example, you can raise a Ruby exception from Rust using Ruby's predefined exception classes.
-///
-/// The syntax for methods like `set_x` differs slightly from typical Rust struct methods because it uses the
-/// [`method!` macro](https://docs.rs/magnus/latest/magnus/macro.method.html):
-/// - The first parameter, `ruby`, gives access to Ruby's runtime.
-/// - The second parameter, `rb_self`, is the Ruby object being called.
-///
-/// @see [`DataTypeFunctions`](https://docs.rs/magnus/latest/magnus/derive.DataTypeFunctions.html)
-/// @see [`TypedData`](https://docs.rs/magnus/latest/magnus/derive.TypedData.html)
+
+// The `wrap` macro wraps a Rust type in a Ruby object, enabling seamless
+// integration.
+//
+// Magnus uses two Ruby API functions to manage the struct:
+// * `rb_data_typed_object_wrap`
+// * `rb_check_typeddata`
+//
+// # Mutability
+//
+// Ruby's garbage collector (GC) manages memory for wrapped objects. This
+// prevents using `&mut` references because Rust requires them to be unique,
+// while Ruby GC may move objects unpredictably. To address this, you can use
+// [`RefCell`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) to
+// enable interior mutability.
+//
+// # Error Handling
+//
+// Use [`magnus::Error`](https://docs.rs/magnus/latest/magnus/struct.Error.html)
+// to propagate errors to Ruby.
+// For example, you can raise a Ruby exception from Rust using Ruby's
+// predefined exception classes.
+//
+// The syntax for methods like `add_x` differs slightly from typical Rust
+// struct methods because it uses the
+// [`method!` macro](https://docs.rs/magnus/latest/magnus/macro.method.html):
+// * The first parameter, `ruby`, gives access to Ruby's runtime.
+// * The second parameter, `rb_self`, is the Ruby object being called.
+//
+// See [`DataTypeFunctions`](https://docs.rs/magnus/latest/magnus/derive.DataTypeFunctions.html)
+// and [`TypedData`](https://docs.rs/magnus/latest/magnus/derive.TypedData.html)
 #[wrap(class = "Point")]
 struct MutPoint(RefCell<Point>);
 
@@ -41,15 +49,20 @@ impl MutPoint {
         self.0.borrow().x
     }
 
-    /// Setter for the x coordinate, with validation
-    ///
-    /// Ensures `x` is positive and raises a Ruby `ArgumentError` if the condition is not met.
-    fn set_x(ruby: &Ruby, rb_self: &Self, i: i32) -> Result<(), Error> {
-        if i <= 0 {
-            return Err(Error::new(ruby.exception_arg_error(), "x must be positive"));
+    fn set_x(&self, val: isize) {
+        self.0.borrow_mut().x = val;
+    }
+
+    fn add_x(ruby: &Ruby, rb_self: &Self, val: isize) -> Result<isize, Error> {
+        if let Some(sum) = rb_self.0.borrow().x.checked_add(val) {
+            rb_self.0.borrow_mut().x = sum;
+            Ok(sum)
+        } else {
+            return Err(Error::new(
+                ruby.exception_range_error(),
+                "result out of range",
+            ));
         }
-        rb_self.0.borrow_mut().x = i as isize;
-        Ok(())
     }
 
     fn y(&self) -> isize {
@@ -58,6 +71,18 @@ impl MutPoint {
 
     fn set_y(&self, val: isize) {
         self.0.borrow_mut().y = val;
+    }
+
+    fn add_y(ruby: &Ruby, rb_self: &Self, val: isize) -> Result<isize, Error> {
+        if let Some(sum) = rb_self.0.borrow().y.checked_add(val) {
+            rb_self.0.borrow_mut().y = sum;
+            Ok(sum)
+        } else {
+            return Err(Error::new(
+                ruby.exception_range_error(),
+                "result out of range",
+            ));
+        }
     }
 
     fn distance(&self, other: &MutPoint) -> f64 {
@@ -71,8 +96,10 @@ fn main() -> Result<(), String> {
         class.define_singleton_method("new", function!(MutPoint::new, 2))?;
         class.define_method("x", method!(MutPoint::x, 0))?;
         class.define_method("x=", method!(MutPoint::set_x, 1))?;
+        class.define_method("add_x", method!(MutPoint::add_x, 1))?;
         class.define_method("y", method!(MutPoint::y, 0))?;
         class.define_method("y=", method!(MutPoint::set_y, 1))?;
+        class.define_method("add_y", method!(MutPoint::add_y, 1))?;
         class.define_method("distance", method!(MutPoint::distance, 1))?;
 
         let d: f64 = ruby.eval(

--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -303,7 +303,7 @@ where
     /// Types that contain Ruby values by default do not participate in
     /// generational GC (they are scanned every GC). This flag asserts all
     /// operations that write Ruby values to this type are protected with
-    /// write barriers (see [`typed_data::Writebarrier::writebarrier`]) so this
+    /// write barriers (see [`Writebarrier::writebarrier`]) so this
     /// type can participate in generational GC.
     ///
     /// This is hard to get right, and it is recomended you do not use this

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -1,6 +1,6 @@
-use magnus::rb_assert;
-use magnus::{Error, Ruby};
 use std::time::SystemTime;
+
+use magnus::{rb_assert, Error, Ruby};
 
 #[test]
 fn test_all() {


### PR DESCRIPTION
Fixes #123

I took our conversations as input to update the README with new example.
Then I also updated the examples as well as inline documentations in the macro.

I fixed a few other problems:

- deprecated usage
- doctests if they went wrong