### PR TITLE
Fix markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,4 +560,4 @@ library turns out better for you.
 
 This project is licensed under the MIT license, see [LICENSE].
 
-[LICENSE]: /LICENSE
+[LICENSE]: https://github.com/matsadler/magnus/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Magnus allows you to wrap Rust structs and enums as Ruby objects, enabling seaml
 
 Use one of the following approaches to expose a Rust type to Ruby:
 
-* A convenience macro [`#[magnus::wrap]`].
+* A convenience macro [`#[magnus::wrap]`][magnus-wrap].
 * More customised approach by implementing the [`magnus::TypedData`] trait.
 
-[`#[magnus::wrap]`]: https://docs.rs/magnus/latest/magnus/attr.wrap.html
-[`magnus::TypedData`]:  https://docs.rs/magnus/latest/magnus/derive.TypedData.html
+[magnus-wrap]: https://docs.rs/magnus/latest/magnus/attr.wrap.html
+[`magnus::TypedData`]: https://docs.rs/magnus/latest/magnus/derive.TypedData.html
 
 Then this Rust type can be:
 
@@ -558,4 +558,6 @@ library turns out better for you.
 
 ## License
 
-This project is licensed under the MIT license, see LICENSE.
+This project is licensed under the MIT license, see [LICENSE].
+
+[LICENSE]: /LICENSE


### PR DESCRIPTION
I found links broken in #125. I tried this part of text with a GitHub-flavored markdown editor. The auto-link probably doesn't work with the nested `[]`. The other standard, commonmark doesn't accept either link. Anyway, here is the fix to render links properly.

Also, I link the LICENSE document.