### PR TITLE
[README] Add link to optify as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,10 @@ deserialisation of Rust to Ruby data structures and vice versa.
 
 * [`halton`](https://github.com/matsadler/halton-rb) a Ruby gem providing a
   highly optimised method for generating Halton sequences.
+* [`optify`](https://github.com/juharris/optify) a Ruby gem to
+  simplify using configuration files to manage options for experiments.
+  It has a GitHub action to publish the gem for different architectures to RubyGems
+  with a RBI file for type hints.
 
 Please open a [pull request](https://github.com/matsadler/magnus/pulls) if
 you'd like your project listed here.


### PR DESCRIPTION
Thanks so much for this awesome project! It was really helpful for me to leverage a library in Rust and then create a Ruby gem for it. I pieced together many things from examples and digging deep into the source code for magnus, halton, rbsys, and other stuff to figure out how to:
* build a gem
* for different architectures
* with type hints
* cross-compiled and published with a GitHub action

It was tricky to get all of the details just right (for example, as a Ruby novice, I wasn't even sure if I needed to or how to publish the gem for different operating systems), and to be honest, maybe I could still use some tweaks to my [gemspec](https://github.com/juharris/optify/blob/main/ruby/optify/optify.gemspec) or Rakefile. I think my repo, optify, is very complete example of how to use magnus. Would you like to reference it?