### PR TITLE
Use stable rb-sys macros for `RTypedData` stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,18 +280,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4dec4b1d304c3b308a2cd86b1216ea45dd4361f4e9fa056f108332d0a450c1"
+checksum = "b5792b4ea6610acc874f17bd6ced47c9384f224851ff54d71160aca7ea4e9214"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d71de3e29d174b8fb17b5d4470f27d7aa2605f8a9d05fda0d3aeff30e05a570"
+checksum = "99a5c39dde51057378e99ed29b9e28951172bdfb74290989c7eea4eb28cdc0b5"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rb-sys = []
 bytes = { version = "1", optional = true }
 chrono = { version = "0.4.38", optional = true }
 magnus-macros = { version = "0.6.0", path = "magnus-macros" }
-rb-sys = { version = "0.9.102", default-features = false, features = [
+rb-sys = { version = ">=0.9.113", default-features = false, features = [
     "bindgen-rbimpls",
     "bindgen-deprecated-types",
     "stable-api",
@@ -45,12 +45,12 @@ magnus = { path = ".", default-features = false, features = [
     "bytes",
     "chrono",
 ] }
-rb-sys = { version = "0.9", default-features = false, features = [
+rb-sys = { version = "0.9.113", default-features = false, features = [
     "stable-api-compiled-fallback",
 ] }
 
 [build-dependencies]
-rb-sys-env = "0.1.2"
+rb-sys-env = "0.2.2"
 
 [lib]
 doc-scrape-examples = false

--- a/examples/complete_object/ext/temperature/Cargo.lock
+++ b/examples/complete_object/ext/temperature/Cargo.lock
@@ -173,18 +173,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4dec4b1d304c3b308a2cd86b1216ea45dd4361f4e9fa056f108332d0a450c1"
+checksum = "b5792b4ea6610acc874f17bd6ced47c9384f224851ff54d71160aca7ea4e9214"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d71de3e29d174b8fb17b5d4470f27d7aa2605f8a9d05fda0d3aeff30e05a570"
+checksum = "99a5c39dde51057378e99ed29b9e28951172bdfb74290989c7eea4eb28cdc0b5"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
 
 [[package]]
 name = "regex"

--- a/examples/custom_exception_ruby/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_ruby/ext/ahriman/Cargo.lock
@@ -181,18 +181,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4dec4b1d304c3b308a2cd86b1216ea45dd4361f4e9fa056f108332d0a450c1"
+checksum = "b5792b4ea6610acc874f17bd6ced47c9384f224851ff54d71160aca7ea4e9214"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d71de3e29d174b8fb17b5d4470f27d7aa2605f8a9d05fda0d3aeff30e05a570"
+checksum = "99a5c39dde51057378e99ed29b9e28951172bdfb74290989c7eea4eb28cdc0b5"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
 
 [[package]]
 name = "regex"

--- a/examples/custom_exception_rust/ext/ahriman/Cargo.lock
+++ b/examples/custom_exception_rust/ext/ahriman/Cargo.lock
@@ -181,18 +181,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4dec4b1d304c3b308a2cd86b1216ea45dd4361f4e9fa056f108332d0a450c1"
+checksum = "b5792b4ea6610acc874f17bd6ced47c9384f224851ff54d71160aca7ea4e9214"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d71de3e29d174b8fb17b5d4470f27d7aa2605f8a9d05fda0d3aeff30e05a570"
+checksum = "99a5c39dde51057378e99ed29b9e28951172bdfb74290989c7eea4eb28cdc0b5"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
 
 [[package]]
 name = "regex"

--- a/examples/rust_blank/ext/rust_blank/Cargo.lock
+++ b/examples/rust_blank/ext/rust_blank/Cargo.lock
@@ -173,18 +173,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4dec4b1d304c3b308a2cd86b1216ea45dd4361f4e9fa056f108332d0a450c1"
+checksum = "b5792b4ea6610acc874f17bd6ced47c9384f224851ff54d71160aca7ea4e9214"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.102"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d71de3e29d174b8fb17b5d4470f27d7aa2605f8a9d05fda0d3aeff30e05a570"
+checksum = "99a5c39dde51057378e99ed29b9e28951172bdfb74290989c7eea4eb28cdc0b5"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
 
 [[package]]
 name = "regex"

--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -20,7 +20,7 @@ use rb_sys::rbimpl_typeddata_flags::{self, RUBY_TYPED_FREE_IMMEDIATELY, RUBY_TYP
 use rb_sys::{
     self, rb_data_type_struct__bindgen_ty_1, rb_data_type_t, rb_gc_writebarrier,
     rb_gc_writebarrier_unprotect, rb_obj_reveal, rb_singleton_class_attached,
-    rb_singleton_class_clone, size_t, VALUE,
+    rb_singleton_class_clone, size_t, RTYPEDDATA_GET_DATA, VALUE,
 };
 
 #[cfg(ruby_lt_3_0)]
@@ -848,7 +848,12 @@ where
     /// # Ruby::init(example).unwrap()
     /// ```
     fn deref(&self) -> &Self::Target {
-        self.inner.get().unwrap()
+        // Since we've already validated the inner during `TryConvert` via `RTypedData::get`, we
+        // can skip the extra checks and libruby calls and just access the data directly.
+        unsafe {
+            let data_ptr = RTYPEDDATA_GET_DATA(self.inner.as_rb_value()) as *mut Self::Target;
+            &*data_ptr
+        }
     }
 }
 


### PR DESCRIPTION
In Ruby 3.5, the RTypedData struct definition was [modified to optimize its size](https://github.com/ruby/ruby/pull/13190), which broke ruby-head builds for apps using magnus gems. To address this, I implemented stable API support for the necessary features in [#530](https://github.com/oxidize-rb/rb-sys/pull/530), ensuring that ruby-head is now compatible.

Also, I took the opportunity to optimize `TypedData::deref` with the new `RTYPEDDATA_GET_DATA` macro to avoid an extra libruby call