### PR TITLE
Test Ruby 3.4 in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
                     - "3.1"
                     - "3.2"
                     - "3.3"
+                    - "3.4"
                     - head
                 rustup-toolchain:
                     - "1.65"
@@ -30,6 +31,8 @@ jobs:
                 exclude:
                     - os: windows-latest
                       ruby-version: "3.3"
+                    - os: windows-latest
+                      ruby-version: "3.4"
                     - os: windows-latest
                       ruby-version: head
                     # The setup-ruby pre-built Ruby 3.1 is built on macos-11

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ use `unsafe`.
 
 ## Compatibility
 
-Ruby versions 3.0, 3.1, 3.2, and 3.3 are fully supported.
+Ruby versions 3.0, 3.1, 3.2, 3.3 and 3.4 are fully supported.
 
 Magnus currently works with, and is still tested against, Ruby 2.7, but as this
 version of the language is no longer supported by the Ruby developers it is not
@@ -487,7 +487,7 @@ recommended and future support in Magnus is not guaranteed.
 Ruby bindings will be generated at compile time, this may require libclang to
 be installed.
 
-The Minimum supported Rust version is currently Rust 1.65.
+The minimum supported Rust version is currently Rust 1.65.
 
 Support for statically linking Ruby is provided via the lower-level [rb-sys]
 crate, and can be enabled by adding the following to your `Cargo.toml`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1114,10 +1114,6 @@
 // * `rb_native_mutex_unlock`:
 // * `rb_need_block`:
 // * `RB_NEGFIXABLE`:
-// * `RB_NEWOBJ`:
-// * `rb_newobj`:
-// * `RB_NEWOBJ_OF`:
-// * `rb_newobj_of`:
 // * `RB_NIL_P`:
 // * `rb_nogvl`:
 // * `rb_notimplement`:


### PR DESCRIPTION
I don't expect anything go wrong with 3.4. So adding tests in CI.

These symbols are removed from 3.4. magnus will never implement them so I removed them too.

// * `RB_NEWOBJ`:
// * `rb_newobj`:
// * `RB_NEWOBJ_OF`:
// * `rb_newobj_of`:

https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/