### PR TITLE
Improve Windows CI compilation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,15 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            # TODO: fix LLVM 20 support (windows-2022's LLVM) when
+            # upstreams (e.g., rb-sys and bindgen) support LLVM 20 on Windows.
+            # LLVM 20 introduced new types but bindgen seems not support new types yet.
+            - name: Install LLVM 18 (on Windows)
+              if: runner.os == 'Windows'
+              uses: KyleMayes/install-llvm-action@v2
+              with:
+                  version: 18
+
             - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
               with:
                   rustup-toolchain: ${{ matrix.rustup-toolchain }}


### PR DESCRIPTION
I am not familiar with bindgen but tried to improve the situation with LLVM 18.

This looks like a common problem when using bindgen from ChatGPT.

```
error[E0587]: type has conflicting packed and align representation hints
     --> D:\a\magnus\magnus\target\debug\build\rb-sys-dff9367561de1403\out\bindings-0.9.116-mri-x64-mingw32-2.7.8.rs:18668:5
      |
18668 |     pub union __mingw_ldbl_type_t {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

@ianks Can you give a hand?