### PR TITLE
Fix error message when there's an invalid byte sequence

### DIFF
--- a/src/r_string.rs
+++ b/src/r_string.rs
@@ -1189,7 +1189,7 @@ impl RString {
     unsafe fn as_str_unconstrained<'a>(self) -> Result<&'a str, Error> {
         unsafe {
             self.test_as_str_unconstrained().ok_or_else(|| {
-                let msg: Cow<'static, str> = if self.is_utf8_compatible_encoding() {
+                let msg: Cow<'static, str> = if !self.is_utf8_compatible_encoding() {
                     format!(
                         "expected utf-8, got {}",
                         RbEncoding::from(self.enc_get()).name()

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,4 +1,4 @@
-use magnus::{Value, prelude::*};
+use magnus::{prelude::*, Value};
 
 #[test]
 fn it_converts_to_utf8_string() {
@@ -10,4 +10,14 @@ fn it_converts_to_utf8_string() {
     let s = String::try_convert(val).unwrap();
 
     assert_eq!("café", s);
+
+    let val: Value = magnus::eval!(r#""\xFF\xFF""#).unwrap();
+    let err = String::try_convert(val).unwrap_err();
+
+    let expected_error = "invalid byte sequence in UTF-8";
+    assert!(
+        err.to_string().contains(expected_error),
+        "Expected \"{}\" to contain \"{expected_error}\" but it didn't",
+        err.to_string()
+    );
 }


### PR DESCRIPTION
I noticed after trying to update a library to Magnus 0.8.1 that the error message that's emitted when a string contains an invalid byte sequence changed. For example, if I have a Ruby string that looks like `"\xFF\xFF"` and try to convert it to a Rust string, I get the error message `#<EncodingError: expected utf-8, got UTF-8 (param at index 0)>` instead of an error message saying the string contains an invalid byte sequence.

After looking at the code, I think the conditional in `as_str_unconstrained` should be inverted so the message for an unexpected encoding error is emitted for non-UTF-8 strings and the invalid byte sequence error is emitted if the string is UTF-8 but contains an invalid byte sequence.
