### PR TITLE
Avoid caching GVL state for Ruby threads

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -41,9 +41,7 @@ impl RubyGvlState {
 
     fn cached() -> Self {
         match RUBY_GVL_STATE.get() {
-            // assumed not to change because there's currently no api to
-            // unlock.
-            Some(Self::Locked) => Self::Locked,
+            Some(Self::Locked) => Self::current(),
             None => Self::current(),
             // Don't expect without an api to unlock, so skip cache
             Some(Self::Unlocked) => Self::current(),


### PR DESCRIPTION
Currently, the GVL state cache assumes the GVL cannot be unlocked since Magnus doesn't have an API to unlock it. However, it's possible to unlock it with `rb-sys`, which makes the cached value incorrect.