### PR TITLE
✨ feat: Support Ruby 4.1 (ruby-head) w/ handle_weak_references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,18 +294,14 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f900d1ce4629a2ebffaf5de74bd8f9c1188d4c5ed406df02f97e22f77a006f44"
+version = "0.9.123"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e9c857028f631056bcd6d88cec390c751e343ce2223ddb26d23eb4a151d59"
+version = "0.9.123"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -319,8 +315,6 @@ dependencies = [
 [[package]]
 name = "rb-sys-env"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,11 @@ io = []
 bytes = { version = "1", optional = true }
 chrono = { version = "0.4.38", optional = true }
 magnus-macros = { version = "0.9.0", path = "magnus-macros" }
-rb-sys = { version = ">=0.9.113", default-features = false, features = [
+rb-sys = { path = "../rb-sys/crates/rb-sys", default-features = false, features = [
     "bindgen-rbimpls",
     "bindgen-deprecated-types",
     "stable-api",
+    "stable-api-compiled-fallback",
 ] }
 seq-macro = "0.3"
 
@@ -49,12 +50,12 @@ magnus = { path = ".", default-features = false, features = [
     "chrono",
     "io",
 ] }
-rb-sys = { version = "0.9.113", default-features = false, features = [
+rb-sys = { path = "../rb-sys/crates/rb-sys", default-features = false, features = [
     "stable-api-compiled-fallback",
 ] }
 
 [build-dependencies]
-rb-sys-env = "0.2.2"
+rb-sys-env = { path = "../rb-sys/crates/rb-sys-env" }
 
 [lib]
 doc-scrape-examples = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ io = []
 bytes = { version = "1", optional = true }
 chrono = { version = "0.4.38", optional = true }
 magnus-macros = { version = "0.9.0", path = "magnus-macros" }
-rb-sys = { path = "../rb-sys/crates/rb-sys", default-features = false, features = [
+rb-sys = { version = ">=0.9.124", default-features = false, features = [
     "bindgen-rbimpls",
     "bindgen-deprecated-types",
     "stable-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ io = []
 bytes = { version = "1", optional = true }
 chrono = { version = "0.4.38", optional = true }
 magnus-macros = { version = "0.9.0", path = "magnus-macros" }
-rb-sys = { version = ">=0.9.124", default-features = false, features = [
+rb-sys = { version = ">= 0.9.124", default-features = false, features = [
     "bindgen-rbimpls",
     "bindgen-deprecated-types",
     "stable-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ magnus = { path = ".", default-features = false, features = [
     "chrono",
     "io",
 ] }
-rb-sys = { path = "../rb-sys/crates/rb-sys", default-features = false, features = [
+rb-sys = { version = ">= 0.9.124", default-features = false, features = [
     "stable-api-compiled-fallback",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rb-sys = { path = "../rb-sys/crates/rb-sys", default-features = false, features 
 ] }
 
 [build-dependencies]
-rb-sys-env = { path = "../rb-sys/crates/rb-sys-env" }
+rb-sys-env = "0.2.3"
 
 [lib]
 doc-scrape-examples = false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,4 +25,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.6.9
+   4.0.3

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = rb_sys_env::activate()?;
 
+    // Declare Ruby 4.1 cfg flags (for ruby-head support)
+    println!("cargo::rustc-check-cfg=cfg(ruby_lt_4_1)");
+    println!("cargo::rustc-check-cfg=cfg(ruby_gte_4_1)");
+
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = rb_sys_env::activate()?;
 
-    // Declare Ruby 4.1 cfg flags (for ruby-head support)
-    println!("cargo::rustc-check-cfg=cfg(ruby_lt_4_1)");
-    println!("cargo::rustc-check-cfg=cfg(ruby_gte_4_1)");
-
     Ok(())
 }

--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -364,12 +364,21 @@ where
         };
         DataType(rb_data_type_t {
             wrap_struct_name: self.name.as_ptr() as _,
+            #[cfg(ruby_lt_4_1)]
             function: rb_data_type_struct__bindgen_ty_1 {
                 dmark,
                 dfree,
                 dsize,
                 dcompact,
                 reserved: [ptr::null_mut(); 1],
+            },
+            #[cfg(ruby_gte_4_1)]
+            function: rb_data_type_struct__bindgen_ty_1 {
+                dmark,
+                dfree,
+                dsize,
+                dcompact,
+                handle_weak_references: None,
             },
             parent: ptr::null(),
             data: ptr::null_mut(),


### PR DESCRIPTION
This PR adds support for Ruby 4.1 (ruby-head) by conditionally compiling the `rb_data_type_struct__bindgen_ty_1` initialization based on Ruby version.

# Problem

Ruby 4.1 changed the `rb_data_type_struct` C struct, replacing the `reserved` field with `handle_weak_references`. This breaks compilation of magnus against ruby-head.

# Solution

Use conditional compilation with `#[cfg(ruby_lt_4_1)]` and `#[cfg(ruby_gte_4_1)]` to select the appropriate struct initialization:

```rust
DataType(rb_data_type_t {
    wrap_struct_name: self.name.as_ptr() as _,
    #[cfg(ruby_lt_4_1)]
    function: rb_data_type_struct__bindgen_ty_1 {
        dmark,
        dfree,
        dsize,
        dcompact,
        reserved: [ptr::null_mut(); 1],
    },
    #[cfg(ruby_gte_4_1)]
    function: rb_data_type_struct__bindgen_ty_1 {
        dmark,
        dfree,
        dsize,
        dcompact,
        handle_weak_references: None,
    },
    parent: ptr::null(),
    data: ptr::null_mut(),
    flags,
})
```

## Changes

1. **`src/typed_data.rs`**
   - Added conditional compilation for `DataTypeBuilder::build()` method
   - Ruby < 4.1: Uses `reserved: [ptr::null_mut(); 1]`
   - Ruby >= 4.1: Uses `handle_weak_references: None`

2. **`build.rs`**
   - Added `cargo::rustc-check-cfg` declarations for `ruby_lt_4_1` and `ruby_gte_4_1`

3. **`Cargo.toml`** (development only)
   - Added `stable-api-compiled-fallback` feature to rb-sys dependencies for Ruby 4.0+ support

## Dependencies

This PR requires a new release of the `rb_sys` gem, likely >= 0.9.124.

- [x] https://github.com/oxidize-rb/rb-sys/issues/696
- [x] https://github.com/oxidize-rb/rb-sys/pull/697

## Testing

- [x] Builds successfully with Ruby 3.x
- [x] Builds successfully with Ruby 4.0.0
- [x] Builds successfully with Ruby 4.1.0 (ruby-head)
- [x] All existing tests pass

## Notes

The `handle_weak_references` field is set to `None` for now, as weak reference support is a new feature in Ruby 4.1. A future enhancement could expose this functionality through the magnus API.

Closes #163

---

## Additional Notes

### About handle_weak_references

The `handle_weak_references` field in Ruby 4.1 is a callback function pointer that Ruby's GC can use to notify the extension when an object's weak references need to be updated. Setting it to `None` is safe and maintains the previous behavior where typed data objects don't participate in weak reference tracking.

A future enhancement to magnus could expose this functionality:

```rust
pub trait DataTypeFunctions {
    // Existing methods...
    
    /// Called by GC to handle weak references (Ruby 4.1+)
    fn handle_weak_references(&self) {
        // Default: no-op
    }
}
```

### Backward Compatibility

This change is fully backward compatible:
- Ruby < 4.1: Compiles with `reserved` field as before
- Ruby >= 4.1: Compiles with new `handle_weak_references` field

No changes to user code are required.