### PR TITLE
fix: typed data init for Ruby 4.1+ reserved field

### DIFF
--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -372,7 +372,9 @@ where
                 #[cfg(ruby_lt_4_1)]
                 reserved: [ptr::null_mut(); 1],
                 #[cfg(ruby_gte_4_1)]
-                reserved: [ptr::null_mut(); 1],
+                // Ruby 4.1 expands rtypeddata's reserved slots; keep in sync with
+                // https://github.com/ruby/ruby/blob/master/include/ruby/internal/core/rtypeddata.h
+                reserved: [ptr::null_mut(); 7],
                 #[cfg(ruby_gte_4_1)]
                 handle_weak_references: None,
             },

--- a/tests/typed_data.rs
+++ b/tests/typed_data.rs
@@ -22,5 +22,5 @@ fn it_wraps_rust_struct() {
     rb_assert!(ruby, "val.class == Example", val);
 
     let ex: &Example = eval!(ruby, "val", val).unwrap();
-    assert_eq!("foo", ex.value)
+    assert_eq!("foo", ex.value);
 }


### PR DESCRIPTION
Also documents reserved slots

Closes #166 
See https://github.com/oxidize-rb/rb-sys/pull/706