### PR TITLE
Return `Error` instead of `String`.

### DIFF
--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -6,7 +6,7 @@ fn fib(n: usize) -> usize {
     }
 }
 
-fn main() {
+fn main() -> Result<(), magnus::Error> {
     magnus::Ruby::init(|ruby| {
         ruby.define_global_function("fib", magnus::function!(fib, 1));
 
@@ -15,5 +15,4 @@ fn main() {
 
         Ok(())
     })
-    .unwrap()
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,7 +2,7 @@ fn hello(subject: String) -> String {
     format!("hello, {}", subject)
 }
 
-fn main() {
+fn main() -> Result<(), magnus::Error> {
     magnus::Ruby::init(|ruby| {
         ruby.define_global_function("hello", magnus::function!(hello, 1));
 
@@ -11,5 +11,4 @@ fn main() {
 
         Ok(())
     })
-    .unwrap()
 }

--- a/examples/inheritance.rs
+++ b/examples/inheritance.rs
@@ -31,7 +31,7 @@ fn print_area(s: &Shape) {
     println!("{}", s.area());
 }
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), magnus::Error> {
     // Normal Rust code
     let a = Shape::Circle { radius: 10.0 };
     let b = Shape::Rectangle { x: 10.0, y: 2.0 };

--- a/examples/mut_point.rs
+++ b/examples/mut_point.rs
@@ -92,7 +92,7 @@ impl MutPoint {
     }
 }
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), magnus::Error> {
     magnus::Ruby::init(|ruby| {
         let class = ruby.define_class("Point", ruby.class_object())?;
         class.define_singleton_method("new", function!(MutPoint::new, 2))?;

--- a/examples/point.rs
+++ b/examples/point.rs
@@ -24,7 +24,7 @@ impl Point {
     }
 }
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), magnus::Error> {
     magnus::Ruby::init(|ruby| {
         let class = ruby.define_class("Point", ruby.class_object())?;
         class.define_singleton_method("new", function!(Point::new, 2))?;

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -189,15 +189,17 @@ impl Ruby {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), magnus::Error> {
     /// magnus::Ruby::init(|ruby| {
     ///     let result: i64 = ruby.eval("2 + 2")?;
     ///     assert_eq!(result, 4);
     ///     Ok(())
-    /// })
-    /// .unwrap()
+    /// })?;
+    /// # Ok(())
+    /// # }
     /// ```
-    pub fn init(func: fn(&Ruby) -> Result<(), Error>) -> Result<(), String> {
-        unsafe { func(&init()) }.map_err(|e| e.to_string())
+    pub fn init<T>(func: fn(&Ruby) -> Result<T, Error>) -> Result<T, Error> {
+        unsafe { func(&init()) }
     }
 
     /// Sets the current script name.

--- a/src/error.rs
+++ b/src/error.rs
@@ -315,6 +315,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl From<Exception> for Error {
     fn from(val: Exception) -> Self {
         Self(ErrorType::Exception(val))


### PR DESCRIPTION
Return a proper `Error` type instead of a `String` that cannot be matched against.