### PR TITLE
Add functions for modifying GVL

### DIFF
--- a/src/gvl.rs
+++ b/src/gvl.rs
@@ -1,0 +1,87 @@
+//! Functions for working with Ruby's GVL.
+
+use std::ffi::c_void;
+use std::ptr::null_mut;
+
+use rb_sys::{rb_thread_call_with_gvl, rb_thread_call_without_gvl};
+
+use crate::{Ruby, error::RubyUnavailableError};
+
+impl Ruby {
+    /// Acquire the GVL.
+    pub fn with_gvl<T, F>(func: F) -> T
+    where
+        F: FnOnce(&Ruby) -> T,
+    {
+        match Ruby::get() {
+            Ok(ruby) => func(&ruby),
+            Err(RubyUnavailableError::GvlUnlocked) => {
+                let mut data = CallbackData {
+                    func: Some(func),
+                    result: None,
+                };
+
+                unsafe {
+                    rb_thread_call_with_gvl(
+                        Some(call_with_gvl::<F, T>),
+                        &mut data as *mut _ as *mut c_void,
+                    );
+                }
+
+                data.result.unwrap()
+            }
+            Err(RubyUnavailableError::NonRubyThread) => {
+                panic!("cannot modify GVL from non-Ruby thread")
+            }
+        }
+    }
+
+    /// Release the GVL.
+    pub fn without_gvl<T, F>(&self, func: F) -> T
+    where
+        F: Send + FnOnce() -> T,
+        T: Send,
+    {
+        let mut data = CallbackData {
+            func: Some(func),
+            result: None,
+        };
+
+        unsafe {
+            rb_thread_call_without_gvl(
+                Some(call_without_gvl::<F, T>),
+                &mut data as *mut _ as *mut c_void,
+                None,
+                null_mut(),
+            );
+        }
+
+        data.result.unwrap()
+    }
+}
+
+struct CallbackData<F, T> {
+    func: Option<F>,
+    result: Option<T>,
+}
+
+extern "C" fn call_without_gvl<F, T>(data: *mut c_void) -> *mut c_void
+where
+    F: FnOnce() -> T,
+{
+    let data = unsafe { &mut *(data as *mut CallbackData<F, T>) };
+    let func = data.func.take().unwrap();
+    data.result = Some(func());
+    null_mut()
+}
+
+extern "C" fn call_with_gvl<F, T>(data: *mut c_void) -> *mut c_void
+where
+    F: FnOnce(&Ruby) -> T,
+{
+    let ruby = Ruby::get().unwrap();
+    let data = unsafe { &mut *(data as *mut CallbackData<F, T>) };
+    let func = data.func.take().unwrap();
+    data.result = Some(func(&ruby));
+    null_mut()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1802,6 +1802,7 @@ pub mod exception;
 pub mod fiber;
 mod float;
 pub mod gc;
+pub mod gvl;
 mod integer;
 mod into_value;
 #[cfg(feature = "io")]

--- a/tests/gvl.rs
+++ b/tests/gvl.rs
@@ -1,0 +1,21 @@
+use magnus::{Ruby, error::RubyUnavailableError};
+
+#[test]
+fn it_can_modify_gvl() {
+    let ruby = unsafe { magnus::embed::init() };
+
+    ruby.without_gvl(|| {
+        assert!(matches!(
+            Ruby::get(),
+            Err(RubyUnavailableError::GvlUnlocked)
+        ));
+
+        Ruby::with_gvl(|_| {
+            assert!(Ruby::get().is_ok());
+        });
+    });
+
+    Ruby::with_gvl(|_| {
+        assert!(Ruby::get().is_ok());
+    });
+}


### PR DESCRIPTION
Adds `with_gvl` and `without_gvl` functions. This is the approach I'm currently using for [Ruby Polars](https://github.com/ankane/ruby-polars).

Addresses #129 