### PR TITLE
Move `&Ruby` to first argument after receiver for methods

### DIFF
--- a/examples/complete_object/ext/temperature/src/lib.rs
+++ b/examples/complete_object/ext/temperature/src/lib.rs
@@ -37,8 +37,8 @@ fn c_to_f(c: f64) -> f64 {
 
 impl Temperature {
     fn initialize(
+        &self,
         ruby: &Ruby,
-        rb_self: typed_data::Obj<Self>,
         args: &[Value],
     ) -> Result<(), Error> {
         let args = scan_args::<(), (), (), (), _, ()>(args)?;
@@ -47,7 +47,7 @@ impl Temperature {
             &[],
             &["kelvin", "celsius", "fahrenheit"],
         )?;
-        *rb_self.microkelvin.borrow_mut() = match kwargs.optional {
+        *self.microkelvin.borrow_mut() = match kwargs.optional {
             (Some(k), None, None) => (k * FACTOR) as u64,
             (None, Some(c), None) => ((c + C_OFFSET) * FACTOR) as u64,
             (None, None, Some(f)) => ((f_to_c(f) + C_OFFSET) * FACTOR) as u64,

--- a/examples/mut_point.rs
+++ b/examples/mut_point.rs
@@ -32,8 +32,8 @@ struct Point {
 // The syntax for methods like `add_x` differs slightly from typical Rust
 // struct methods because it uses the
 // [`method!` macro](https://docs.rs/magnus/latest/magnus/macro.method.html):
-// * The first parameter, `ruby`, gives access to Ruby's runtime.
-// * The second parameter, `rb_self`, is the Ruby object being called.
+// * The first parameter, `rb_self`, is the Ruby object being called.
+// * The second parameter, `ruby`, gives access to Ruby's runtime.
 //
 // See [`DataTypeFunctions`](https://docs.rs/magnus/latest/magnus/derive.DataTypeFunctions.html)
 // and [`TypedData`](https://docs.rs/magnus/latest/magnus/derive.TypedData.html)
@@ -53,10 +53,10 @@ impl MutPoint {
         self.0.borrow_mut().x = val;
     }
 
-    fn add_x(ruby: &Ruby, rb_self: &Self, val: isize) -> Result<isize, Error> {
-        match rb_self.0.borrow().x.checked_add(val) {
+    fn add_x(&self, ruby: &Ruby, val: isize) -> Result<isize, Error> {
+        match self.0.borrow().x.checked_add(val) {
             Some(sum) => {
-                rb_self.0.borrow_mut().x = sum;
+                self.0.borrow_mut().x = sum;
                 Ok(sum)
             }
             _ => Err(Error::new(
@@ -74,10 +74,10 @@ impl MutPoint {
         self.0.borrow_mut().y = val;
     }
 
-    fn add_y(ruby: &Ruby, rb_self: &Self, val: isize) -> Result<isize, Error> {
-        match rb_self.0.borrow().y.checked_add(val) {
+    fn add_y(&self, ruby: &Ruby, val: isize) -> Result<isize, Error> {
+        match self.0.borrow().y.checked_add(val) {
             Some(sum) => {
-                rb_self.0.borrow_mut().y = sum;
+                self.0.borrow_mut().y = sum;
                 Ok(sum)
             }
             _ => Err(Error::new(

--- a/src/block.rs
+++ b/src/block.rs
@@ -1083,7 +1083,7 @@ where
 /// ```
 /// use magnus::{Error, Ruby, Value, block::Yield, method, prelude::*, rb_assert};
 ///
-/// fn count_to_3(ruby: &Ruby, rb_self: Value) -> Yield<impl Iterator<Item = u8> + use<>> {
+/// fn count_to_3(rb_self: Value, ruby: &Ruby) -> Yield<impl Iterator<Item = u8> + use<>> {
 ///     if ruby.block_given() {
 ///         Yield::Iter(1..=3)
 ///     } else {
@@ -1127,8 +1127,8 @@ pub enum Yield<I> {
 /// use magnus::{Error, Ruby, Value, block::YieldValues, method, prelude::*, rb_assert};
 ///
 /// fn count_to_3_abc(
-///     ruby: &Ruby,
 ///     rb_self: Value,
+///     ruby: &Ruby,
 /// ) -> YieldValues<impl Iterator<Item = (u8, char)> + use<>> {
 ///     if ruby.block_given() {
 ///         YieldValues::Iter((1..=3).zip('a'..='c'))
@@ -1173,8 +1173,8 @@ pub enum YieldValues<I> {
 /// use magnus::{Error, RArray, Ruby, Value, block::YieldSplat, method, prelude::*, rb_assert};
 ///
 /// fn count_to_3_abc(
-///     ruby: &Ruby,
 ///     rb_self: Value,
+///     ruby: &Ruby,
 /// ) -> YieldSplat<impl Iterator<Item = RArray> + use<>> {
 ///     if ruby.block_given() {
 ///         YieldSplat::Iter((1..=3).zip('a'..='c').map(|(i, c)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2318,7 +2318,7 @@ impl Ruby {
     /// ```
     /// use magnus::{Error, Ruby, Value, method, prelude::*, rb_assert};
     ///
-    /// fn test(ruby: &Ruby, rb_self: Value) -> Result<bool, Error> {
+    /// fn test(rb_self: Value, ruby: &Ruby) -> Result<bool, Error> {
     ///     rb_self.equal(ruby.current_receiver::<Value>()?)
     /// }
     ///

--- a/src/method.rs
+++ b/src/method.rs
@@ -728,7 +728,7 @@ where
 #[doc(hidden)]
 pub trait RubyMethodCAry<RbSelf, Res>
 where
-    Self: Sized + Fn(&Ruby, RbSelf, &[Value]) -> Res,
+    Self: Sized + Fn(RbSelf, &Ruby, &[Value]) -> Res,
     RbSelf: TryConvert,
     Res: ReturnValue,
 {
@@ -742,7 +742,7 @@ where
     ) -> Result<Value, Error> {
         unsafe {
             let args = slice::from_raw_parts(argv, argc as usize);
-            (self)(ruby, TryConvert::try_convert(rb_self)?, args).into_return_value_with(ruby)
+            (self)(TryConvert::try_convert(rb_self)?, ruby, args).into_return_value_with(ruby)
         }
     }
 
@@ -771,7 +771,7 @@ where
 
 impl<Func, RbSelf, Res> RubyMethodCAry<RbSelf, Res> for Func
 where
-    Func: Fn(&Ruby, RbSelf, &[Value]) -> Res,
+    Func: Fn(RbSelf, &Ruby, &[Value]) -> Res,
     RbSelf: TryConvert,
     Res: ReturnValue,
 {
@@ -832,7 +832,7 @@ macro_rules! method_n {
             #[doc(hidden)]
             pub trait $ruby_name<RbSelf, #(T~N,)* Res>
             where
-                Self: Sized + Fn(&Ruby, RbSelf, #(T~N,)*) -> Res,
+                Self: Sized + Fn(RbSelf, &Ruby, #(T~N,)*) -> Res,
                 RbSelf: TryConvert,
                 #(T~N: TryConvert,)*
                 Res: ReturnValue,
@@ -840,8 +840,8 @@ macro_rules! method_n {
                 #[inline]
                 fn call_convert_value(self, ruby: &Ruby, rb_self: Value, #(arg~N: Value,)*) -> Result<Value, Error> {
                     (self)(
-                        ruby,
                         TryConvert::try_convert(rb_self)?,
+                        ruby,
                         #(TryConvert::try_convert(arg~N)?,)*
                     ).into_return_value_with(ruby)
                 }
@@ -864,7 +864,7 @@ macro_rules! method_n {
 
             impl<Func, RbSelf, #(T~N,)* Res> $ruby_name<RbSelf, #(T~N,)* Res> for Func
             where
-                Func: Fn(&Ruby, RbSelf, #(T~N,)*) -> Res,
+                Func: Fn(RbSelf, &Ruby, #(T~N,)*) -> Res,
                 RbSelf: TryConvert,
                 #(T~N: TryConvert,)*
                 Res: ReturnValue,

--- a/src/r_typed_data.rs
+++ b/src/r_typed_data.rs
@@ -108,7 +108,7 @@ impl Ruby {
     /// }
     ///
     /// impl Point {
-    ///     fn new(ruby: &Ruby, class: RClass, x: isize, y: isize) -> RTypedData {
+    ///     fn new(class: RClass, ruby: &Ruby, x: isize, y: isize) -> RTypedData {
     ///         ruby.wrap_as(Self { x, y }, class)
     ///     }
     /// }

--- a/src/typed_data.rs
+++ b/src/typed_data.rs
@@ -681,7 +681,7 @@ impl Ruby {
     /// }
     ///
     /// impl Point {
-    ///     fn new(ruby: &Ruby, class: RClass, x: isize, y: isize) -> typed_data::Obj<Self> {
+    ///     fn new(class: RClass, ruby: &Ruby, x: isize, y: isize) -> typed_data::Obj<Self> {
     ///         ruby.obj_wrap_as(Self { x, y }, class)
     ///     }
     /// }

--- a/tests/return_iter.rs
+++ b/tests/return_iter.rs
@@ -1,6 +1,6 @@
 use magnus::{Ruby, Value, block::Yield, eval, method, prelude::*, rb_assert};
 
-fn count_to_3(ruby: &Ruby, rb_self: Value) -> Yield<impl Iterator<Item = u8> + use<>> {
+fn count_to_3(rb_self: Value, ruby: &Ruby) -> Yield<impl Iterator<Item = u8> + use<>> {
     if ruby.block_given() {
         Yield::Iter(1..=3)
     } else {

--- a/tests/scan_args.rs
+++ b/tests/scan_args.rs
@@ -2,12 +2,12 @@ use magnus::{
     RArray, RHash, Ruby, Symbol,
     block::Proc,
     error::Error,
-    method,
+    function,
     scan_args::{get_kwargs, scan_args},
     value::Value,
 };
 
-fn example(ruby: &Ruby, _rb_self: Value, args: &[Value]) -> Result<RArray, Error> {
+fn example(ruby: &Ruby, args: &[Value]) -> Result<RArray, Error> {
     let args = scan_args(args)?;
     let (a,): (String,) = args.required;
     let (b,): (Option<String>,) = args.optional;
@@ -44,7 +44,7 @@ fn example(ruby: &Ruby, _rb_self: Value, args: &[Value]) -> Result<RArray, Error
 fn it_scans_args() {
     let ruby = unsafe { magnus::embed::init() };
 
-    ruby.define_global_function("example", method!(example, -1));
+    ruby.define_global_function("example", function!(example, -1));
 
     let res = ruby.eval::<bool>(r#"
         example("a", "b", "splat1", "splat2", :c, d: 1, f: 2, h: 3) == ["a", "b", ["splat1", "splat2"], :c, 1, 2, {h: 3}]

--- a/tests/yield.rs
+++ b/tests/yield.rs
@@ -1,6 +1,6 @@
-use magnus::{Error, Ruby, Value, eval, method, rb_assert};
+use magnus::{Error, Ruby, Value, eval, function, rb_assert};
 
-fn flipflop(ruby: &Ruby, _rb_self: Value, mut val: bool) -> Result<(), Error> {
+fn flipflop(ruby: &Ruby, mut val: bool) -> Result<(), Error> {
     val = ruby.yield_value(val)?;
     loop {
         val = ruby.yield_value(!val)?;
@@ -11,7 +11,7 @@ fn flipflop(ruby: &Ruby, _rb_self: Value, mut val: bool) -> Result<(), Error> {
 fn it_yields() {
     let ruby = unsafe { magnus::embed::init() };
 
-    ruby.define_global_function("flipflop", method!(flipflop, 1));
+    ruby.define_global_function("flipflop", function!(flipflop, 1));
 
     let values = ruby.ary_new();
     let i: Value = eval!(


### PR DESCRIPTION
This allows for using `&self` with `&Ruby` (similar to `&self` and `py: Python<'_>` with PyO3), but is a fairly large breaking change.

Closes #160